### PR TITLE
avbroot/vbmeta.py: Force signing algorithm from SHA256_RSA2048 to SHA256_RSA4096

### DIFF
--- a/avbroot/vbmeta.py
+++ b/avbroot/vbmeta.py
@@ -108,6 +108,11 @@ def patch_vbmeta_root(avb, images, input_path, output_path, key, padding_size):
 
     algorithm_name = avbtool.lookup_algorithm_by_type(header.algorithm_type)[0]
 
+    # Some older Pixel devices' vbmeta images are originally signed by a
+    # 2048-bit RSA key, but avbroot expects RSA 4096 keys
+    if algorithm_name == 'SHA256_RSA2048':
+        algorithm_name = 'SHA256_RSA4096'
+
     with util.open_output_file(output_path) as f:
         # Smuggle in the prebuilt descriptors via kernel_cmdlines
         with smuggle_descriptors():


### PR DESCRIPTION
This is the same as commit 163540b2b68a0aa0123c413ed776be9405f65571, except for the vbmeta image. Some older devices' vbmeta images were originally signed by an RSA 4096 key.

Fixes: #9