### PR TITLE
avbroot.py: Use the output directory as the default temporary directory path

### DIFF
--- a/avbroot.py
+++ b/avbroot.py
@@ -209,6 +209,10 @@ def patch_subcommand(args):
     if output is None:
         output = args.input + '.patched'
 
+    # Set default temp directory to the output directory because this is the
+    # only way to control where external libraries put their temp files
+    tempfile.tempdir = os.path.dirname(os.path.abspath(output))
+
     # Decrypt keys to temp directory
     with tempfile.TemporaryDirectory(dir=util.tmpfs_path()) as key_dir:
         print_status(f'Decrypting keys to temporary directory: {key_dir}')
@@ -251,6 +255,10 @@ def patch_subcommand(args):
 
 
 def extract_subcommand(args):
+    # Set default temp directory to the output directory because this is the
+    # only way to control where external libraries put their temp files
+    tempfile.tempdir = os.path.abspath(args.directory)
+
     with zipfile.ZipFile(args.input, 'r') as z:
         info = z.getinfo(PATH_PAYLOAD)
 


### PR DESCRIPTION
Systems where `/tmp` is on a tmpfs and have less free RAM may have trouble with the patching process.