### PR TITLE
Stop setting default temporary directory to the output directory

### DIFF
--- a/avbroot.py
+++ b/avbroot.py
@@ -243,10 +243,6 @@ def patch_subcommand(args):
     if output is None:
         output = args.input + '.patched'
 
-    # Set default temp directory to the output directory because this is the
-    # only way to control where external libraries put their temp files
-    util.set_default_temp_dir(os.path.dirname(os.path.abspath(output)))
-
     # Decrypt keys to temp directory
     with tempfile.TemporaryDirectory(dir=util.tmpfs_path()) as key_dir:
         print_status(f'Decrypting keys to temporary directory: {key_dir}')
@@ -289,10 +285,6 @@ def patch_subcommand(args):
 
 
 def extract_subcommand(args):
-    # Set default temp directory to the output directory because this is the
-    # only way to control where external libraries put their temp files
-    util.set_default_temp_dir(os.path.abspath(args.directory))
-
     with zipfile.ZipFile(args.input, 'r') as z:
         info = z.getinfo(PATH_PAYLOAD)
 

--- a/avbroot/util.py
+++ b/avbroot/util.py
@@ -57,19 +57,6 @@ def tmpfs_path():
     return None
 
 
-def set_default_temp_dir(path):
-    '''
-    Set the default temporary directory for use if the user hasn't overridden
-    it with standard environment variables.
-    '''
-
-    if any(os.getenv(k) for k in ('TMPDIR', 'TEMP', 'TMP')):
-        # Rely on tempfile's default handling
-        return
-
-    tempfile.tempdir = path
-
-
 @contextlib.contextmanager
 def open_output_file(path):
     '''


### PR DESCRIPTION
Now that avbroot no longer needs to create huge temp files, just use the OS's default temp directory.