### PR TITLE
Add support for OnePlus OTAs

### DIFF
--- a/avbroot/ota.py
+++ b/avbroot/ota.py
@@ -92,7 +92,8 @@ def _extract_image(f_payload, f_out, block_size, blob_offset, partition):
             else:
                 raise Exception(f'Unsupported operation: {op.type}')
 
-            if h_data.digest() != op.data_sha256_hash:
+            # OnePlus OTA payloads don't specify a checksum for ZERO blocks
+            if h_data.digest() != op.data_sha256_hash and op.type != Type.ZERO:
                 raise Exception('Expected hash %s, but got %s' %
                                 (h_data.hexdigest(),
                                  binascii.hexlify(op.data_sha256_hash)))


### PR DESCRIPTION
Only OxygenOS 12 and 13 can work because older builds use the legacy metadata file instead of the newer protobuf format.

Differences from Pixel devices:

* There's a `recovery` image. It contains `otacerts.zip` instead of `vendor_boot` or `boot`. The image uses a version 4 `ANDROID!` header, not `VNDRBOOT`.
* The `payload.bin` uses `ZERO` blocks with no sha256 checksum.