### PR TITLE
avbroot/boot.py: Construct Magisk ramdisk from scratch if no ramdisk exists

### DIFF
--- a/avbroot/formats/cpio.py
+++ b/avbroot/formats/cpio.py
@@ -140,7 +140,7 @@ class CpioEntryNew:
             self.chksum = _read_int(f)
 
             # Filename
-            self._name = util.read_exact(f, self.namesize - 1)
+            self._name = bytes(util.read_exact(f, self.namesize - 1))
             # Discard NULL terminator
             util.read_exact(f, 1)
             padding.read_skip(f, 4)


### PR DESCRIPTION
On bluejay, the boot image does not contain a ramdisk. In this scenario, magiskboot creates a new lz4_legacy-compressed ramdisk, so we'll do the same.

This commit also changes the .backup/ directory structure generation so that it is done dynamically.

Fixes: #42