### PR TITLE
avbroot/formats/compression.py: Hardcode timestamp in gzip header

### DIFF
--- a/avbroot/formats/compression.py
+++ b/avbroot/formats/compression.py
@@ -167,7 +167,7 @@ class CompressedFile:
                     break
 
         if format == Format.GZIP:
-            format_fp = gzip.open(fp, mode)
+            format_fp = gzip.GzipFile(fileobj=fp, mode=mode, mtime=0)
         elif format == Format.LZ4_LEGACY:
             format_fp = Lz4Legacy(fp, mode)
         else:


### PR DESCRIPTION
For v2 boot images that use gzip headers, the current system time was begin added to the gzip header while recompressing the ramdisk, which broke reproducibility. This commit hardcodes the timestamp to 0 (unix epoch time).