### PR TITLE
Add new bootimagetool and cpiotool utilities

### DIFF
--- a/avbroot/util.py
+++ b/avbroot/util.py
@@ -136,4 +136,8 @@ def read_exact(f, size: int) -> bytes:
         raise EOFError(f'Unexpected EOF: expected {size} bytes, '
                        f'but only read {len(data)} bytes')
 
-    return data
+    if not isinstance(data, bytes):
+        # io.BytesIO returns a bytearray
+        return bytes(data)
+    else:
+        return data

--- a/extra/README.md
+++ b/extra/README.md
@@ -29,3 +29,34 @@ python bootimagetool.py repack <input boot image> <output boot image>
 ```
 
 This subcommand repacks a boot image without writing the individual components to disk first. This is useful for roundtrip testing of avbroot's boot image parser. The output should be identical to the input, minus any footers, like the AVB footer. The only exception is the VTS signature for v4 boot images, which is always stripped out.
+
+## `cpiotool`
+
+This is a frontend to the [`avbroot/formats/compression.py`](../avbroot/formats/compression.py) and [`avbroot/formats/cpio.py`](../avbroot/formats/cpio.py) libraries. It is useful for inspecting compressed and uncompressed cpio archives.
+
+### Dumping a cpio archive
+
+```bash
+python cpiotool.py dump <cpio archive>
+```
+
+This subcommand dumps all information about a cpio archive to stdout. This includes the compression format, all header fields (including the trailer entry), and all data. If an entry's data can be decoded as UTF-8, then it is printed out as text. Otherwise, the binary data is printed out base64-encoded. The base64-encoded data is truncated to 5 lines by default to avoid outputting too much data, but this behavior can be disabled with `--no-truncate`.
+
+### Repacking a cpio archive
+
+```bash
+python cpiotool.py repack <input cpio archive> <output cpio archive>
+```
+
+This subcommand repacks a cpio archive, including recompression if needed. This is useful for roundtrip testing of avbroot's cpio parser and compression handling. The uncompressed output should be identical to the uncompressed input, except:
+
+* files are sorted by name
+* inodes are reassigned, starting from 300000
+* there is no excess padding at the end of the file
+
+The compressed output may differ from what other tools produce because:
+
+* LZ4 legacy chunks are packed to exactly 8 MiB, except for the last chunk, which may be smaller.
+* LZ4 legacy uses the high compression mode with a compression level of 12.
+* The GZIP header has the modification timestamp set to 0 (Unix epoch time).
+* GZIP uses a compression level of 9.

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,0 +1,31 @@
+# avbroot extra
+
+This directory contains some extra scripts that aren't required for avbroot's operation, but may be useful for troubleshooting.
+
+## `bootimagetool`
+
+This is a frontend to the [`avbroot/formats/bootimage.py`](../avbroot/formats/bootimage.py) library for working with boot images.
+
+### Unpacking a boot image
+
+```bash
+python bootimagetool.py unpack <input boot image>
+```
+
+This subcommand unpacks all of the components of the boot image into the current directory by default (see `--help`). The header fields are saved to `header.json` and each blob section is saved to a separate file. Each blob is written to disk as-is, without decompression.
+
+### Packing a boot image
+
+```bash
+python bootimagetool.py pack <output boot image>
+```
+
+This subcommand packs a new boot image from the individual components in the current directory by default (see `--help`). The default input filenames are the same as the output filenames for the `unpack` subcommand.
+
+### Repacking a boot image
+
+```bash
+python bootimagetool.py repack <input boot image> <output boot image>
+```
+
+This subcommand repacks a boot image without writing the individual components to disk first. This is useful for roundtrip testing of avbroot's boot image parser. The output should be identical to the input, minus any footers, like the AVB footer. The only exception is the VTS signature for v4 boot images, which is always stripped out.

--- a/extra/bootimagetool.py
+++ b/extra/bootimagetool.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+import argparse
+import itertools
+import json
+import os
+import sys
+
+sys.path.append(os.path.join(sys.path[0], '..'))
+from avbroot.formats import bootimage
+
+
+class BytesDecoder(json.JSONDecoder):
+    def __init__(self):
+        super().__init__(object_hook=self.from_dict)
+
+    @staticmethod
+    def from_dict(d):
+        # This is insufficient for arbitrary data, but we're not dealing with
+        # arbitrary data
+        if 'type' in d:
+            if d['type'] == 'UTF-8':
+                return d['data'].encode('UTF-8')
+            elif d['type'] == 'hex':
+                return bytes.fromhex(d['data'])
+
+        return d
+
+
+class BytesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            if b'\0' not in obj:
+                try:
+                    return {
+                        'type': 'UTF-8',
+                        'data': obj.decode('UTF-8'),
+                    }
+                except UnicodeDecodeError:
+                    pass
+
+            return {
+                'type': 'hex',
+                'data': obj.hex(),
+            }
+
+        return super().default(obj)
+
+
+def read_or_none(path):
+    try:
+        with open(path, 'rb') as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+
+def write_if_not_none(path, data):
+    if data is not None:
+        with open(path, 'wb') as f:
+            f.write(data)
+
+
+def parse_args():
+    parser_kwargs = {'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
+
+    parser = argparse.ArgumentParser(**parser_kwargs)
+    subparsers = parser.add_subparsers(dest='subcommand', required=True,
+                                       help='Subcommands')
+
+    base = argparse.ArgumentParser(add_help=False)
+    base.add_argument('-q', '--quiet', action='store_true',
+                      help='Do not print header information')
+
+    pack = subparsers.add_parser('pack', help='Pack a boot image',
+                                 parents=[base], **parser_kwargs)
+    unpack = subparsers.add_parser('unpack', help='Unpack a boot image',
+                                   parents=[base], **parser_kwargs)
+    repack = subparsers.add_parser('repack', help='Repack a boot image',
+                                   parents=[base], **parser_kwargs)
+
+    for p in (pack, unpack):
+        prefix = '--input-' if p == pack else '--output-'
+
+        p.add_argument('boot_image', help='Path to boot image')
+
+        p.add_argument(prefix + 'header', default='header.json',
+                       help='Path to header JSON')
+        p.add_argument(prefix + 'kernel', default='kernel.img',
+                       help='Path to kernel')
+        p.add_argument(prefix + 'ramdisk-prefix', default='ramdisk.img.',
+                       help='Path prefix for ramdisk')
+        p.add_argument(prefix + 'second', default='second.img',
+                       help='Path to second stage bootloader')
+        p.add_argument(prefix + 'recovery-dtbo', default='recovery_dtbo.img',
+                       help='Path to recovery dtbo/acpio')
+        p.add_argument(prefix + 'dtb', default='dtb.img',
+                       help='Path to device tree blob')
+        p.add_argument(prefix + 'bootconfig', default='bootconfig.txt',
+                       help='Path to bootconfig')
+
+    repack.add_argument('input', help='Path to input boot image')
+    repack.add_argument('output', help='Path to output boot image')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.subcommand == 'pack':
+        with open(args.input_header, 'r') as f:
+            data = json.load(f, cls=BytesDecoder)
+
+        img = bootimage.create_from_dict(data)
+
+        img.kernel = read_or_none(args.input_kernel)
+        img.second = read_or_none(args.input_second)
+        img.recovery_dtbo = read_or_none(args.input_recovery_dtbo)
+        img.dtb = read_or_none(args.input_dtb)
+        img.bootconfig = read_or_none(args.input_bootconfig)
+
+        for i in itertools.count():
+            ramdisk = read_or_none(f'{args.input_ramdisk_prefix}{i}')
+            if ramdisk is None:
+                break
+
+            img.ramdisks.append(ramdisk)
+
+        if not args.quiet:
+            print(img)
+
+        with open(args.boot_image, 'wb') as f:
+            img.generate(f)
+
+    elif args.subcommand == 'unpack':
+        with open(args.boot_image, 'rb') as f:
+            img = bootimage.load_autodetect(f)
+            if not args.quiet:
+                print(img)
+
+        with open(args.output_header, 'w') as f:
+            json.dump(img.to_dict(), f, indent=4, cls=BytesEncoder)
+
+        write_if_not_none(args.output_kernel, img.kernel)
+        write_if_not_none(args.output_second, img.second)
+        write_if_not_none(args.output_recovery_dtbo, img.recovery_dtbo)
+        write_if_not_none(args.output_dtb, img.dtb)
+        write_if_not_none(args.output_bootconfig, img.bootconfig)
+
+        for i, ramdisk in enumerate(img.ramdisks):
+            write_if_not_none(f'{args.output_ramdisk_prefix}{i}', ramdisk)
+
+    elif args.subcommand == 'repack':
+        with open(args.input, 'rb') as f:
+            img = bootimage.load_autodetect(f)
+            if not args.quiet:
+                print(img)
+
+        with open(args.output, 'wb') as f:
+            img.generate(f)
+
+    else:
+        raise NotImplementedError()
+
+
+if __name__ == '__main__':
+    main()

--- a/extra/cpiotool.py
+++ b/extra/cpiotool.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import os
+import sys
+
+sys.path.append(os.path.join(sys.path[0], '..'))
+from avbroot.formats import compression
+from avbroot.formats import cpio
+
+
+CONTENT_BEGIN = '----- BEGIN UTF-8 CONTENT -----'
+CONTENT_END = '----- END UTF-8 CONTENT -----'
+CONTENT_END_NO_NEWLINE = '----- END UTF-8 CONTENT (NO NEWLINE) -----'
+
+BASE64_BEGIN = '----- BEGIN BASE64 CONTENT -----'
+BASE64_END = '----- END BASE64 CONTENT -----'
+BASE64_END_TRUNCATED = '----- END BASE64 CONTENT (TRUNCATED) -----'
+
+NO_DATA = '----- NO DATA -----'
+
+
+def print_content(data, truncate=False):
+    if not data:
+        print(NO_DATA)
+        return
+
+    if b'\0' not in data:
+        try:
+            data_str = data.decode('UTF-8')
+
+            if CONTENT_BEGIN not in data_str \
+                    and CONTENT_END not in data_str \
+                    and CONTENT_END_NO_NEWLINE not in data_str:
+                print(CONTENT_BEGIN)
+                print(data_str, end='')
+                if data_str[-1] != '\n':
+                    print()
+                    print(CONTENT_END_NO_NEWLINE)
+                else:
+                    print(CONTENT_END)
+
+            return
+        except UnicodeDecodeError:
+            pass
+
+    data_base64 = base64.b64encode(data).decode('ascii')
+
+    print(BASE64_BEGIN)
+    for i, offset in enumerate(range(0, len(data_base64), 76)):
+        if truncate and i == 5:
+            print(BASE64_END_TRUNCATED)
+            return
+
+        print(data_base64[offset:offset + 76])
+    print(BASE64_END)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', required=True,
+                                       help='Subcommands')
+
+    dump = subparsers.add_parser('dump', help='Dump cpio headers and data')
+    repack = subparsers.add_parser('repack', help='Repack cpio archive')
+
+    dump.add_argument('--no-truncate', action='store_true',
+                      help='Do not truncate binary file contents')
+
+    for p in (dump, repack):
+        p.add_argument('input', help='Path to input cpio file')
+
+    repack.add_argument('output', help='Path to output cpio file')
+
+    return parser.parse_args()
+
+
+def load_archive(path, **cpio_kwargs):
+    with open(path, 'rb') as f_raw:
+        decompressed = False
+
+        try:
+            with compression.CompressedFile(f_raw, 'rb') as f:
+                decompressed = True
+                return cpio.load(f.fp, **cpio_kwargs), f.format
+        except ValueError:
+            # Not the best API
+            if decompressed:
+                raise
+            else:
+                f_raw.seek(0)
+                return cpio.load(f_raw, **cpio_kwargs), None
+
+
+def save_archive(path, entries, format):
+    with open(path, 'wb') as f_raw:
+        if format:
+            with compression.CompressedFile(f_raw, 'wb', format=format) as f:
+                cpio.save(f.fp, entries)
+        else:
+            cpio.save(f_raw, entries)
+
+
+def main():
+    args = parse_args()
+
+    if args.subcommand == 'dump':
+        entries, format = load_archive(
+            args.input,
+            # We want to show the headers exactly as they are
+            include_trailer=True,
+            reassign_inodes=False,
+        )
+
+        print('Compression format:', format)
+        print()
+
+        for entry in entries:
+            print(entry)
+            print_content(entry.content, truncate=not args.no_truncate)
+            print()
+
+    elif args.subcommand == 'repack':
+        entries, format = load_archive(args.input)
+        save_archive(args.output, entries, format)
+
+    else:
+        raise NotImplementedError()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/tests.conf
+++ b/tests/tests.conf
@@ -8,7 +8,7 @@ url = https://dl.google.com/dl/android/aosp/cheetah-ota-tq1a.230205.002-ad27a6d7
 sha256 = ad27a6d7ca78c0d3fb7f51864cc6a9e6bc91f536f9e9bab5da06253df602525f
 sha256_patched = a711b2033a6ebe39c2ba22e885bd570db33092897eda1793e508f3e8ffb8000a
 
-# What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4)
+# What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
 [device.GooglePixel6a]
 url = https://dl.google.com/dl/android/aosp/bluejay-ota-tq1a.230205.002-1ec64b58.zip
 sha256 = 1ec64b589cba8d9687ea8f85cf6c2e5d09c9e4fbdae15417aa06d5ba976fbe79


### PR DESCRIPTION
This PR adds a couple of new tools for working with boot images and cpio archives on the command line. They're just small wrappers around avbroot's `avbroot.formats.*` libraries. They're useful for dissecting and comparing boot images when troubleshooting.