### PR TITLE
tests: Add infrastructure for running tests in podman

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -22,3 +22,21 @@ python tests/tests.py
 To only run the tests for a specific device, pass in `-d <device>`. This argument can be specified multiple times (eg. `-d GooglePixel7Pro -d GooglePixel6a`).
 
 To pass in extra arguments to `aria2c`, use `-a=<arg>`. This can be used to enable concurrent downloads (eg. `-a=-x4 -a=-s4`).
+
+## Running the tests in a container
+
+The tests can also be run inside a podman container for easy testing on various Linux distros. To do so, run:
+
+```bash
+python tests/tests_containerized.py
+```
+
+This will build all of the images defined in [`distros/Containerfile.<distro>`](./distros/) and run the tests inside new container instances concurrently. By default, the number of concurrent jobs is set to the number of CPUs. This can be changed with `-j <num>`.
+
+To only run tests against a specific set of distro images, use `-d <distro>`, which can be specified multiple times. All arguments after a `--` argument are passed to `tests.py` directly.
+
+For example, to test patching the Google Pixel 7 Pro OTA against the Fedora and Arch images, run:
+
+```bash
+python tests/tests_containerized.py -d fedora -d arch -- -d GooglePixel7Pro
+```

--- a/tests/distros/Containerfile.alpine
+++ b/tests/distros/Containerfile.alpine
@@ -1,0 +1,3 @@
+FROM docker.io/library/alpine:3.17
+
+RUN apk add --no-cache aria2 openssl py3-lz4 py3-protobuf

--- a/tests/distros/Containerfile.arch
+++ b/tests/distros/Containerfile.arch
@@ -1,0 +1,4 @@
+FROM docker.io/archlinux/archlinux:latest
+
+RUN pacman --noconfirm -Syu --needed aria2 openssl python-lz4 python-protobuf \
+    && pacman --noconfirm -Scc

--- a/tests/distros/Containerfile.debian
+++ b/tests/distros/Containerfile.debian
@@ -1,0 +1,5 @@
+FROM docker.io/library/debian:11
+
+RUN apt-get -y update \
+    && apt-get -y install aria2 openssl python3-lz4 python3-protobuf \
+    && find /var/cache/apt/archives /var/lib/apt/lists -mindepth 1 -delete

--- a/tests/distros/Containerfile.fedora
+++ b/tests/distros/Containerfile.fedora
@@ -1,0 +1,4 @@
+FROM registry.fedoraproject.org/fedora-toolbox:37
+
+RUN dnf install -y aria2 openssl python3-lz4 python3-protobuf \
+    && find /var/cache/dnf -mindepth 1 -delete

--- a/tests/distros/Containerfile.opensuse
+++ b/tests/distros/Containerfile.opensuse
@@ -1,0 +1,4 @@
+FROM registry.opensuse.org/opensuse/toolbox:latest
+
+RUN zypper install -y aria2 openssl python3-lz4 python3-protobuf \
+    && zypper clean -a

--- a/tests/distros/Containerfile.ubuntu
+++ b/tests/distros/Containerfile.ubuntu
@@ -1,0 +1,5 @@
+FROM docker.io/library/ubuntu:22.10
+
+RUN apt-get -y update \
+    && apt-get -y install aria2 openssl python3-lz4 python3-protobuf \
+    && find /var/cache/apt/archives /var/lib/apt/lists -mindepth 1 -delete

--- a/tests/distros/Containerfile.ubuntu-lts
+++ b/tests/distros/Containerfile.ubuntu-lts
@@ -1,0 +1,5 @@
+FROM docker.io/library/ubuntu:22.04
+
+RUN apt-get -y update \
+    && apt-get -y install aria2 openssl python3-lz4 python3-protobuf \
+    && find /var/cache/apt/archives /var/lib/apt/lists -mindepth 1 -delete

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -81,7 +81,10 @@ def run_tests(args, config, files_dir):
             revalidate=args.revalidate,
             extra_args=args.aria2c_arg,
         )
-        patched_file = image_file + '.patched'
+        patched_file = image_file + args.output_file_suffix
+
+        if args.download_only:
+            continue
 
         print('Patching', image_file)
 
@@ -102,6 +105,9 @@ def run_tests(args, config, files_dir):
 
         verify_checksum(patched_file, image['sha256_patched'])
 
+        if args.delete_on_success:
+            os.unlink(patched_file)
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -109,10 +115,21 @@ def parse_args():
                         help='Argument to pass to aria2c')
     parser.add_argument('-d', '--device', action='append',
                         help='Device image to test against')
+    parser.add_argument('--delete-on-success', action='store_true',
+                        help='Delete output files if patching is successful')
+    parser.add_argument('--download-only', action='store_true',
+                        help='Skip patching and download OTA images only')
+    parser.add_argument('--output-file-suffix', default='.patched',
+                        help='Suffix for patched output files')
     parser.add_argument('--revalidate', action='store_true',
                         help='Revalidate checksums for downloaded OTAs')
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if not args.output_file_suffix:
+        parser.error('--output-file-suffix cannot be empty')
+
+    return args
 
 
 def test_main():

--- a/tests/tests_containerized.py
+++ b/tests/tests_containerized.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+import argparse
+import collections
+import os
+import queue
+import subprocess
+import sys
+import threading
+
+
+def build_cmd(image_name, tag, container_file, rebuild=False):
+    full_image = f'{image_name}:{tag}'
+
+    if not rebuild and \
+            subprocess.call(['podman', 'image', 'exists', full_image]) == 0:
+        return None
+
+    return [
+        'podman',
+        'build',
+        '--pull',
+        '-t', full_image,
+        '-f', container_file,
+        os.path.dirname(container_file),
+    ]
+
+
+def test_cmd(image_name, tag, extra_args=[], default_args=True, network=False):
+    full_image = f'{image_name}:{tag}'
+    project_dir = os.path.realpath(os.path.join(sys.path[0], '..'))
+
+    network_args = ['--network', 'none'] if network else []
+    test_args = extra_args.copy()
+    if default_args:
+        test_args.append('--delete-on-success')
+        test_args.append('--output-file-suffix')
+        test_args.append(f'.{tag}')
+
+    return [
+        'podman',
+        'run',
+        '--rm',
+        '-e', 'PYTHONUNBUFFERED=1',
+        # Only make the files directory writable so the multiple Python
+        # versions running concurrently won't clobber each other's compiled
+        # bytecode files
+        '-v', f'{project_dir}:/mnt:ro,z',
+        '-v', f'{project_dir}/tests/files:/mnt/tests/files:z',
+        *network_args,
+        full_image,
+        '/mnt/tests/tests.py',
+        *test_args,
+    ]
+
+
+class PrefixedOutputThread(threading.Thread):
+    def __init__(self, input, name, is_error):
+        super().__init__()
+
+        out_type = 'err' if is_error else 'out'
+
+        self.input = input
+        self.prefix = f'[{name}::{out_type}] '.encode('UTF-8')
+        self.output = sys.stderr.buffer if is_error else sys.stdout.buffer
+
+    def run(self):
+        for line in self.input:
+            self.output.write(self.prefix)
+            self.output.write(line)
+            if not line or line[-1] != ord(b'\n'):
+                self.output.write(b'\n')
+            self.output.flush()
+
+
+class CompletionThread(threading.Thread):
+    def __init__(self, process, name, queue):
+        super().__init__()
+
+        self.process = process
+        self.name = name
+        self.queue = queue
+
+    def run(self):
+        try:
+            self.process.wait()
+        finally:
+            self.queue.put(self.name)
+
+
+class Job:
+    def __init__(self, cmd, name, completion_queue):
+        print(f'Running job {name!r} with command {cmd!r}')
+
+        self.process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.stdout_thread = PrefixedOutputThread(
+            self.process.stdout, name, False)
+        self.stderr_thread = PrefixedOutputThread(
+            self.process.stderr, name, True)
+        self.completion_thread = CompletionThread(
+            self.process, name, completion_queue)
+
+        self.stdout_thread.start()
+        self.stderr_thread.start()
+        self.completion_thread.start()
+
+    def kill(self):
+        self.process.kill()
+
+    def wait(self):
+        self.process.wait()
+        self.stdout_thread.join()
+        self.stderr_thread.join()
+        self.completion_thread.join()
+
+        return self.process.returncode
+
+
+def run_jobs(name_to_cmd, max_jobs):
+    results = {n: None for n in name_to_cmd}
+    job_queue = collections.deque(name_to_cmd.items())
+    jobs = {}
+    completion_queue = queue.Queue()
+
+    try:
+        while job_queue or jobs:
+            # Dispatch new jobs up to the job limit
+            while job_queue and len(jobs) < max_jobs:
+                name, cmd = job_queue.popleft()
+                job = Job(cmd, name, completion_queue)
+                jobs[name] = job
+
+            # Wait for child process to complete
+            name = completion_queue.get()
+            job = jobs.pop(name)
+            results[name] = job.wait()
+    except:
+        for _, job in jobs.items():
+            job.kill()
+        raise
+    finally:
+        for name, job in jobs.items():
+            results[name] = job.wait()
+
+        failed = 0
+
+        if name_to_cmd:
+            max_name_len = max(len(n) for n in name_to_cmd)
+
+            print('Results:')
+            for name, status in sorted(results.items()):
+                print(f'- {name:<{max_name_len}}: ', end='')
+
+                if status is None:
+                    failed += 1
+                    print('Not started')
+                elif status != 0:
+                    failed += 1
+                    print(f'Failed with status: {status}')
+                else:
+                    print('Succeeded')
+
+    if failed != 0:
+        raise Exception(f'{failed} job(s) failed')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('test_arg', nargs='*',
+                        help='Argument to pass to tests.py')
+    parser.add_argument('-d', '--distro', default=[], action='append',
+                        help='Distro container image to run tests in')
+    parser.add_argument('-j', '--jobs', type=int, default=os.cpu_count() or 1,
+                        help='Number of jobs to run concurrently')
+    parser.add_argument('--image-prefix', default='avbroot-tests',
+                        help='Image name prefix (without tag)')
+    parser.add_argument('--rebuild', action='store_true',
+                        help='Rebuild images even if they exist')
+
+    args = parser.parse_args()
+
+    if args.image_prefix and ':' in args.image_prefix:
+        parser.error('--image-prefix should not contain a tag')
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    distros_dir = os.path.join(sys.path[0], 'distros')
+    distros = set(f.removeprefix('Containerfile.')
+                  for f in os.listdir(distros_dir)
+                  if f.startswith('Containerfile.'))
+
+    if args.distro:
+        selected_distros = set(args.distro)
+        invalid = selected_distros - distros
+        if invalid:
+            raise ValueError(f'Invalid distros: {sorted(invalid)}')
+
+        distros = selected_distros
+
+    # Podman image build jobs
+    build_cmds = {}
+    for d in distros:
+        cmd = build_cmd(
+            args.image_prefix,
+            d,
+            os.path.join(distros_dir, f'Containerfile.{d}'),
+            rebuild=args.rebuild,
+        )
+        if cmd:
+            build_cmds[d] = cmd
+
+    # Job to pre-download OTAs
+    download_cmds = {
+        'download': test_cmd(
+            args.image_prefix,
+            # Doesn't matter which distro image we use to download
+            next(iter(distros)),
+            extra_args=['--download-only'],
+            default_args=False,
+            network=True,
+        ),
+    }
+
+    # Test runner jobs
+    test_cmds = {}
+    for d in distros:
+        test_cmds[d] = test_cmd(
+            args.image_prefix,
+            d,
+            extra_args=args.test_arg,
+        )
+
+    # Let it rip!
+    run_jobs(build_cmds, args.jobs)
+    run_jobs(download_cmds, 1)
+    run_jobs(test_cmds, args.jobs)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The officially supported distros are now Alpine, Arch, Debian, Fedora, Fedora, OpenSUSE, and Ubuntu. The new script will build images for these distros and concurrently run `tests.py` inside containers.