### PR TITLE
Add support for Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The boot-related components are signed with an AVB key and OTA-related component
 
 ### Installing dependencies
 
-avbroot depends on `openssl` command line tool and the `lz4` and `protobuf` Python libraries.
+avbroot depends on the `openssl` command line tool and the `lz4` and `protobuf` Python libraries. Also, Python 3.9 or newer is required.
 
 #### Linux
 

--- a/avbroot/formats/bootimage.py
+++ b/avbroot/formats/bootimage.py
@@ -115,17 +115,17 @@ class WrongFormat(ValueError):
 class BootImage:
     def __init__(
         self,
-        f: None | typing.BinaryIO = None,
-        data: None | dict[str, typing.Any] = None,
+        f: typing.Optional[typing.BinaryIO] = None,
+        data: typing.Optional[dict[str, typing.Any]] = None,
     ) -> None:
         assert (f is None) != (data is None)
 
-        self.kernel: None | bytes = None
+        self.kernel: typing.Optional[bytes] = None
         self.ramdisks: list[bytes] = []
-        self.second: None | bytes = None
-        self.recovery_dtbo: None | bytes = None
-        self.dtb: None | bytes = None
-        self.bootconfig: None | bytes = None
+        self.second: typing.Optional[bytes] = None
+        self.recovery_dtbo: typing.Optional[bytes] = None
+        self.dtb: typing.Optional[bytes] = None
+        self.bootconfig: typing.Optional[bytes] = None
 
         if f:
             self._from_file(f)

--- a/avbroot/formats/compression.py
+++ b/avbroot/formats/compression.py
@@ -155,7 +155,7 @@ class CompressedFile:
         self,
         fp: typing.BinaryIO,
         mode: typing.Literal['rb', 'wb'] = 'rb',
-        format: None | Format = None,
+        format: typing.Optional[Format] = None,
     ):
         if mode == 'rb' and not format:
             magic = fp.read(_MAGIC_MAX_SIZE)


### PR DESCRIPTION
This is needed for Debian 11 compatibility.

Fixes: #50