### PR TITLE
Fix skipped cleanup logic caused by fixing bare except lint warnings

### DIFF
--- a/avbroot/ota.py
+++ b/avbroot/ota.py
@@ -701,7 +701,7 @@ def open_signing_wrapper(f, privkey, passphrase, cert):
 
         process.stdin.close()
         signature = process.stdout.read()
-    except Exception:
+    except BaseException:
         process.kill()
         raise
     finally:

--- a/avbroot/util.py
+++ b/avbroot/util.py
@@ -33,7 +33,7 @@ def open_output_file(path):
                     pass
 
             os.rename(f.name, path)
-        except Exception:
+        except BaseException:
             os.unlink(f.name)
             raise
 


### PR DESCRIPTION
This fixes temporary output files sometimes not being cleaned up and openssl cms sometimes not being killed when the user interrupts the process.