### PR TITLE
avbroot/boot.py: Mark otacerts.zip entries as created on Unix

### DIFF
--- a/avbroot/boot.py
+++ b/avbroot/boot.py
@@ -205,6 +205,8 @@ class OtaCertPatch(BootImagePatch):
                     # Use zeroed-out metadata to ensure the archive is bit for
                     # bit reproducible across runs.
                     info = zipfile.ZipInfo('ota.x509.pem')
+                    # Mark entry as created on Unix for reproducibility
+                    info.create_system = 3
                     with (
                         z.open(info, 'w') as f_out,
                         open(self.cert_ota, 'rb') as f_in,


### PR DESCRIPTION
Otherwise, the "version made by" field in the central directory (2 bytes immediately after CD magic) are `\x14\x00` on Windows and `\x14\x03` everywhere else.