### PR TITLE
avbroot/util.py: open_output_file: Close file before unlinking on Windows

### DIFF
--- a/avbroot/util.py
+++ b/avbroot/util.py
@@ -34,6 +34,10 @@ def open_output_file(path):
 
             os.rename(f.name, path)
         except BaseException:
+            if os.name == 'nt':
+                # Windows does not allow deleting a file with handles open
+                f.close()
+
             os.unlink(f.name)
             raise
 


### PR DESCRIPTION
This fixes temporary files being left behind when interrupted on Windows.