### PR TITLE
Add option to clear vbmeta flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ For KernelSU, also pass in `--boot-partition @gki_kernel`. avbroot defaults to M
 
 Note that avbroot will validate that the prepatched image is compatible with the original. If, for example, the header fields do not match or a boot image section is missing, then the patching process will abort. This check is not foolproof, but should help protect against accidental use of the wrong boot image.
 
+### Clearing vbmeta flags
+
+Some Android builds may ship with a root `vbmeta` image with the flags set such that AVB is effectively disabled. When avbroot encounters these images, the patching process will fail with a message like:
+
+```
+ValueError: vbmeta flags disable AVB: 0x3
+```
+
+To forcibly enable AVB (by clearing the flags), pass in `--clear-vbmeta-flags`.
+
 ## Implementation Details
 
 * avbroot relies on AOSP's avbtool and OTA utilities. These are collections of applications that aren't meant to be used as libraries, but avbroot shoehorns them in anyway. These tools are not called via CLI because avbroot requires more control over the operations being performed than what is provided via the CLI interfaces. This "integration" is incredibly hacky and will likely require changes whenever the submodules are updated to point to newer AOSP commits.

--- a/avbroot/main.py
+++ b/avbroot/main.py
@@ -77,8 +77,8 @@ def get_required_images(manifest, boot_partition):
 
 
 def patch_ota_payload(f_in, f_out, file_size, boot_partition, magisk,
-                      prepatched, privkey_avb, passphrase_avb, privkey_ota,
-                      passphrase_ota, cert_ota):
+                      prepatched, clear_vbmeta_flags, privkey_avb,
+                      passphrase_avb, privkey_ota, passphrase_ota, cert_ota):
     with tempfile.TemporaryDirectory() as temp_dir:
         extract_dir = os.path.join(temp_dir, 'extract')
         patch_dir = os.path.join(temp_dir, 'patch')
@@ -141,6 +141,7 @@ def patch_ota_payload(f_in, f_out, file_size, boot_partition, magisk,
             privkey_avb,
             passphrase_avb,
             manifest.block_size,
+            clear_vbmeta_flags,
         )
 
         print_status('Updating OTA payload to reference patched images')
@@ -159,8 +160,8 @@ def patch_ota_payload(f_in, f_out, file_size, boot_partition, magisk,
 
 
 def patch_ota_zip(f_zip_in, f_zip_out, boot_partition, magisk, prepatched,
-                  privkey_avb, passphrase_avb, privkey_ota, passphrase_ota,
-                  cert_ota):
+                  clear_vbmeta_flags, privkey_avb, passphrase_avb, privkey_ota,
+                  passphrase_ota, cert_ota):
     with (
         zipfile.ZipFile(f_zip_in, 'r') as z_in,
         zipfile.ZipFile(f_zip_out, 'w') as z_out,
@@ -248,6 +249,7 @@ def patch_ota_zip(f_zip_in, f_zip_out, boot_partition, magisk, prepatched,
                         boot_partition,
                         magisk,
                         prepatched,
+                        clear_vbmeta_flags,
                         privkey_avb,
                         passphrase_avb,
                         privkey_ota,
@@ -334,6 +336,7 @@ def patch_subcommand(args):
                 args.boot_partition,
                 args.magisk,
                 args.prepatched,
+                args.clear_vbmeta_flags,
                 args.privkey_avb,
                 passphrase_avb,
                 args.privkey_ota,
@@ -395,6 +398,9 @@ def parse_args(argv=None):
 
     patch.add_argument('--ignore-magisk-version', action='store_true',
                        help='Allow patching with unsupported Magisk versions')
+
+    patch.add_argument('--clear-vbmeta-flags', action='store_true',
+                       help='Forcibly clear vbmeta flags if they disable AVB')
 
     extract = subparsers.add_parser(
         'extract', help='Extract patched images from a patched OTA zip')

--- a/avbroot/vbmeta.py
+++ b/avbroot/vbmeta.py
@@ -73,7 +73,7 @@ def _get_descriptor_overrides(avb, paths):
 
 
 def patch_vbmeta_root(avb, images, input_path, output_path, key, passphrase,
-                      padding_size):
+                      padding_size, clear_flags):
     '''
     Patch the root vbmeta image to reference the provided images.
     '''
@@ -81,6 +81,12 @@ def patch_vbmeta_root(avb, images, input_path, output_path, key, passphrase,
     # Load the original root vbmeta image
     image = avbtool.ImageHandler(input_path, read_only=True)
     footer, header, descriptors, image_size = avb._parse_image(image)
+
+    if header.flags != 0:
+        if clear_flags:
+            header.flags = 0
+        else:
+            raise ValueError(f'vbmeta flags disable AVB: 0x{header.flags:x}')
 
     # Build a set of new descriptors in the same order as the original
     # descriptors, except with the descriptors patched to reference the given


### PR DESCRIPTION
Some Android builds ship with a root vbmeta image with flags that disable AVB completely. This commit adds a new check for these flags so that the patching process will fail and also adds a new `--clear-vbmeta-flags` option for forcibly setting the flags to 0.

Issue: #60