### PR TITLE
Use dummy images for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 *.img
 *.zip
 *.patched
+.tox

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -12,10 +12,9 @@ import zipfile
 import tomlkit
 
 sys.path.append(os.path.join(sys.path[0], ".."))
-from avbroot import ota, util
+from avbroot import external, ota, util
 from avbroot.main import PATH_PAYLOAD
-
-ZIP_HEADER_NO_FILENAME_SIZE = 30
+import ota_utils
 
 PARTITIONS_TO_ZERO = {"product", "system", "vendor", "system_ext", "modem"}
 
@@ -152,7 +151,7 @@ def convert_image(args):
         with z.open(info, "r") as f:
             _, manifest, blob_offset = ota.parse_payload(f)
 
-    file_offset = info.header_offset + ZIP_HEADER_NO_FILENAME_SIZE + len(info.filename)
+        file_offset, _ = ota_utils.GetZipEntryOffset(z, info)
 
     partition_operations = {}
 

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+import argparse
+from binascii import crc32
+import contextlib
+import gzip
+import os.path
+import sys
+import urllib.request
+import zipfile
+
+import tomlkit
+
+sys.path.append(os.path.join(sys.path[0], ".."))
+from avbroot import ota, util
+from avbroot.main import PATH_PAYLOAD
+
+ZIP_HEADER_NO_FILENAME_SIZE = 30
+
+PARTITIONS_TO_ZERO = {"product", "system", "vendor", "system_ext", "modem"}
+
+
+class Crc32Hasher:
+    existing_crc32 = None
+
+    def get_checksum(self):
+        return self.existing_crc32
+
+    def set_checksum(self, existing_crc32):
+        self.existing_crc32 = existing_crc32
+
+    def update(self, *args, **kwargs):
+        if self.existing_crc32:
+            args = args + (self.existing_crc32,)
+
+        self.existing_crc32 = crc32(*args, **kwargs)
+
+
+@contextlib.contextmanager
+def output_open(filename, mode, compress=True):
+    if compress and not filename.endswith(".gz"):
+        filename += ".gz"
+
+    if compress:
+        with gzip.GzipFile(filename, mode, compresslevel=1, mtime=0) as f:
+            yield f
+    else:
+        with open(filename, mode) as f:
+            yield f
+
+
+def output_writer(f_in, f_out, size, db=None):
+    if not f_in:
+        util.zero_n(f_out, size)
+    else:
+        crc_hash = None
+        mapping = None
+
+        if db is not None and size != 0:
+            mapping = True
+
+        if mapping:
+            crc_hash = Crc32Hasher()
+
+            # Combine sections if adjacent
+            if db and db[-1]["range"][1] == f_out.tell() - 1:
+                entry = db.pop()
+                crc_hash.set_checksum(entry["checksum"])
+                section_start = entry["range"][0]
+            else:
+                section_start = f_out.tell()
+
+            section_end = f_out.tell() + (size - 1)
+
+        util.copyfileobj_n(f_in, f_out, size, hasher=crc_hash)
+
+        if mapping:
+            db.append(
+                {
+                    "range": [section_start, section_end],
+                    "checksum": crc_hash.get_checksum(),
+                }
+            )
+
+
+def download_file(f_out, url, section):
+    crc_hash = Crc32Hasher()
+
+    req = urllib.request.Request(url)
+    req.add_header("Range", f"bytes={section['range'][0]}-{section['range'][1]}")
+    with urllib.request.urlopen(req) as data:
+        util.copyfileobj_n(
+            data, f_out, section["range"][1] - section["range"][0] + 1, hasher=crc_hash
+        )
+
+    if crc_hash.get_checksum() != int(section["checksum"], 16):
+        raise Exception(f"ERROR: Checksum of range {section['range']} doesn't match")
+
+
+def download_dummy_image(args):
+    with open(args.db, "r") as f:
+        database = f.read()
+
+    database = tomlkit.parse(database)
+
+    device_entry = database["device"].get(args.device_name)
+    if not device_entry:
+        raise Exception(f"ERROR: {args.device_name} cannot be found in the database")
+
+    # Assume we always download the beginning and end (which makes sense for a ZIP file)
+    previous_offset = 0
+    with output_open(args.output, "wb", args.compress) as f_out:
+        for section in device_entry["sections"]:
+            util.zero_n(f_out, section["range"][0] - previous_offset)
+            download_file(f_out, device_entry["url"], section)
+            previous_offset = section["range"][1] + 1
+
+
+def print_entry(db, original_filename):
+    new_map = tomlkit.array()
+    new_map.append(tomlkit.nl())
+
+    for section in db:
+        entry = tomlkit.inline_table()
+
+        for key, value in section.items():
+            entry[key] = f"{value:x}" if key == "checksum" else value
+
+        new_map.append(entry)
+
+    print("*** Add this entry to the database ***")
+    print(
+        tomlkit.dumps(
+            {
+                "device": {
+                    "new_device_name": {
+                        "filename": os.path.basename(original_filename),
+                        "url": "",
+                        "sections": new_map,
+                    }
+                }
+            }
+        )
+    )
+    print("*** End ***")
+
+
+def convert_image(args):
+    with zipfile.ZipFile(args.input, "r") as z:
+        info = z.getinfo(PATH_PAYLOAD)
+
+        with z.open(info, "r") as f:
+            _, manifest, blob_offset = ota.parse_payload(f)
+
+    file_offset = info.header_offset + ZIP_HEADER_NO_FILENAME_SIZE + len(info.filename)
+
+    partition_operations = {}
+
+    for p in manifest.partitions:
+        if p.partition_name in PARTITIONS_TO_ZERO:
+            old_data_offset = 0
+
+            # Ensure all operations are in order
+            for op in p.operations:
+                if old_data_offset > op.data_offset:
+                    raise Exception("Operations are expected to be ordered")
+                old_data_offset = op.data_offset
+
+            partition_operations[p.partition_name] = p.operations
+
+    db = []
+
+    with open(args.input, "rb") as f_in, output_open(
+        args.output, "wb", args.compress
+    ) as f_out:
+        # Copy zip data until payload.bin + payload.bin header
+        output_writer(f_in, f_out, file_offset + blob_offset, db)
+
+        # Sort partitions based on data_offset of first operation and iterate
+        for _, p_operations in sorted(
+            partition_operations.items(), key=lambda x: x[1][0].data_offset
+        ):
+            # Copy all data until first partition offset
+            output_writer(
+                f_in,
+                f_out,
+                p_operations[0].data_offset - (f_in.tell() - file_offset - blob_offset),
+                db,
+            )
+
+            for op in p_operations:
+                if f_out.tell() != (file_offset + blob_offset + op.data_offset):
+                    raise Exception("f_out should be equal to the offset")
+                output_writer(None, f_out, op.data_length, db)
+            f_in.seek(f_out.tell())
+
+        # Copy remaining data
+        f_in.seek(0, 2)
+        remaining_size = f_in.tell() - f_out.tell()
+        f_in.seek(f_out.tell())
+        output_writer(f_in, f_out, remaining_size, db)
+
+    print_entry(db, args.input)
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(
+        dest="subcommand", required=True, help="Subcommands"
+    )
+
+    base = argparse.ArgumentParser(add_help=False)
+    base.add_argument(
+        "--compress",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Compress output file",
+    )
+    base.add_argument("--output", required=True, help="Path to new OTA zip")
+
+    convert = subparsers.add_parser(
+        "convert", help="Convert full OTA zip to dummy zip", parents=[base]
+    )
+    convert.add_argument("--input", required=True, help="Path to original OTA zip")
+
+    download = subparsers.add_parser(
+        "download", help="Assemble dummy zip while downloading", parents=[base]
+    )
+    download.add_argument("--db", required=True, help="Path to database file")
+    download.add_argument("device_name", help="Name of device (as in database)")
+
+    return parser.parse_args(args=args)
+
+
+def main(args=None):
+    args = parse_args(args=args)
+
+    if args.subcommand == "convert":
+        convert_image(args)
+    elif args.subcommand == "download":
+        download_dummy_image(args)
+    else:
+        raise NotImplementedError()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -13,10 +13,10 @@ import tomlkit
 
 sys.path.append(os.path.join(sys.path[0], ".."))
 from avbroot import external, ota, util
-from avbroot.main import PATH_PAYLOAD
+from avbroot.main import PARTITION_PRIORITIES, PATH_PAYLOAD
 import ota_utils
 
-PARTITIONS_TO_ZERO = {"product", "system", "vendor", "system_ext", "modem"}
+PARTITIONS_TO_PRESERVE = set(sum(PARTITION_PRIORITIES.values(), ()))
 
 
 class Crc32Hasher:
@@ -156,7 +156,7 @@ def convert_image(args):
     partition_operations = {}
 
     for p in manifest.partitions:
-        if p.partition_name in PARTITIONS_TO_ZERO:
+        if p.partition_name not in PARTITIONS_TO_PRESERVE:
             old_data_offset = 0
 
             # Ensure all operations are in order

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -194,7 +194,7 @@ def convert_image(args):
             f_in.seek(f_out.tell())
 
         # Copy remaining data
-        f_in.seek(0, 2)
+        f_in.seek(0, os.SEEK_END)
         remaining_size = f_in.tell() - f_out.tell()
         f_in.seek(f_out.tell())
         output_writer(f_in, f_out, remaining_size, db)

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -11,7 +11,7 @@ import zipfile
 
 import tomlkit
 
-sys.path.append(os.path.join(sys.path[0], ".."))
+sys.path.append(os.path.join(sys.path[0], '..'))
 from avbroot import external, ota, util
 from avbroot.main import PARTITION_PRIORITIES, PATH_PAYLOAD
 import ota_utils
@@ -27,12 +27,12 @@ def strtobool(val):
     'val' is anything else.
     """
     val = val.lower()
-    if val in ("y", "yes", "t", "true", "on", "1"):
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
         return 1
-    elif val in ("n", "no", "f", "false", "off", "0"):
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
         return 0
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError('invalid truth value %r' % (val, ))
 
 
 class Crc32Hasher:
@@ -46,15 +46,15 @@ class Crc32Hasher:
 
     def update(self, *args, **kwargs):
         if self.existing_crc32:
-            args = args + (self.existing_crc32,)
+            args = args + (self.existing_crc32, )
 
         self.existing_crc32 = crc32(*args, **kwargs)
 
 
 @contextlib.contextmanager
 def output_open(filename, mode, compress=True):
-    if compress and not filename.endswith(".gz"):
-        filename += ".gz"
+    if compress and not filename.endswith('.gz'):
+        filename += '.gz'
 
     if compress:
         with gzip.GzipFile(filename, mode, compresslevel=1, mtime=0) as f:
@@ -78,10 +78,10 @@ def output_writer(f_in, f_out, size, db=None):
             crc_hash = Crc32Hasher()
 
             # Combine sections if adjacent
-            if db and db[-1]["range"][1] == f_out.tell() - 1:
+            if db and db[-1]['range'][1] == f_out.tell() - 1:
                 entry = db.pop()
-                crc_hash.set_checksum(entry["checksum"])
-                section_start = entry["range"][0]
+                crc_hash.set_checksum(entry['checksum'])
+                section_start = entry['range'][0]
             else:
                 section_start = f_out.tell()
 
@@ -90,45 +90,47 @@ def output_writer(f_in, f_out, size, db=None):
         util.copyfileobj_n(f_in, f_out, size, hasher=crc_hash)
 
         if mapping:
-            db.append(
-                {
-                    "range": [section_start, section_end],
-                    "checksum": crc_hash.get_checksum(),
-                }
-            )
+            db.append({
+                'range': [section_start, section_end],
+                'checksum': crc_hash.get_checksum(),
+            })
 
 
 def download_file(f_out, url, section):
     crc_hash = Crc32Hasher()
 
     req = urllib.request.Request(url)
-    req.add_header("Range", f"bytes={section['range'][0]}-{section['range'][1]}")
+    req.add_header('Range',
+                   f"bytes={section['range'][0]}-{section['range'][1]}")
     with urllib.request.urlopen(req) as data:
-        util.copyfileobj_n(
-            data, f_out, section["range"][1] - section["range"][0] + 1, hasher=crc_hash
-        )
+        util.copyfileobj_n(data,
+                           f_out,
+                           section['range'][1] - section['range'][0] + 1,
+                           hasher=crc_hash)
 
-    if crc_hash.get_checksum() != int(section["checksum"], 16):
-        raise Exception(f"ERROR: Checksum of range {section['range']} doesn't match")
+    if crc_hash.get_checksum() != int(section['checksum'], 16):
+        raise Exception(
+            f"ERROR: Checksum of range {section['range']} doesn't match")
 
 
 def download_dummy_image(args):
-    with open(args.db, "r") as f:
+    with open(args.db, 'r') as f:
         database = f.read()
 
     database = tomlkit.parse(database)
 
-    device_entry = database["device"].get(args.device_name)
+    device_entry = database['device'].get(args.device_name)
     if not device_entry:
-        raise Exception(f"ERROR: {args.device_name} cannot be found in the database")
+        raise Exception(
+            f'ERROR: {args.device_name} cannot be found in the database')
 
     # Assume we always download the beginning and end (which makes sense for a ZIP file)
     previous_offset = 0
-    with output_open(args.output, "wb", args.compress) as f_out:
-        for section in device_entry["sections"]:
-            util.zero_n(f_out, section["range"][0] - previous_offset)
-            download_file(f_out, device_entry["url"], section)
-            previous_offset = section["range"][1] + 1
+    with output_open(args.output, 'wb', args.compress) as f_out:
+        for section in device_entry['sections']:
+            util.zero_n(f_out, section['range'][0] - previous_offset)
+            download_file(f_out, device_entry['url'], section)
+            previous_offset = section['range'][1] + 1
 
 
 def add_entry(db, db_entry, device_name, original_filename):
@@ -139,27 +141,27 @@ def add_entry(db, db_entry, device_name, original_filename):
         entry = tomlkit.inline_table()
 
         for key, value in section.items():
-            entry[key] = f"{value:x}" if key == "checksum" else value
+            entry[key] = f'{value:x}' if key == 'checksum' else value
 
         new_sections.append(entry)
 
     device_entry = {
         device_name: {
-            "filename": os.path.basename(original_filename),
-            "url": "",
-            "sections": new_sections,
+            'filename': os.path.basename(original_filename),
+            'url': '',
+            'sections': new_sections,
         }
     }
 
-    with open(db, "r") as f:
+    with open(db, 'r') as f:
         toml_db = tomlkit.load(f)
 
-    if toml_db.get("device").get(device_name) is not None:
+    if toml_db.get('device').get(device_name) is not None:
         overwrite_entry = None
 
         while overwrite_entry is None:
             choice = input(
-                f"{device_name} is already in the database. Do you want to overwrite it? [y/n] "
+                f'{device_name} is already in the database. Do you want to overwrite it? [y/n] '
             ).lower()
 
             try:
@@ -168,23 +170,25 @@ def add_entry(db, db_entry, device_name, original_filename):
                 pass
 
         if not overwrite_entry:
-            print("Entry not added to the database. It is printed below instead:")
-            print(tomlkit.dumps({"device": device_entry}))
+            print(
+                'Entry not added to the database. It is printed below instead:'
+            )
+            print(tomlkit.dumps({'device': device_entry}))
             return
 
-    toml_db.get("device").update(device_entry)
+    toml_db.get('device').update(device_entry)
 
-    with open(db, "w") as f:
+    with open(db, 'w') as f:
         tomlkit.dump(toml_db, f)
 
-    print(f"{device_name} is added to the database")
+    print(f'{device_name} is added to the database')
 
 
 def convert_image(args):
-    with zipfile.ZipFile(args.input, "r") as z:
+    with zipfile.ZipFile(args.input, 'r') as z:
         info = z.getinfo(PATH_PAYLOAD)
 
-        with z.open(info, "r") as f:
+        with z.open(info, 'r') as f:
             _, manifest, blob_offset = ota.parse_payload(f)
 
         file_offset, _ = ota_utils.GetZipEntryOffset(z, info)
@@ -203,28 +207,27 @@ def convert_image(args):
                     continue
 
                 if old_data_offset > op.data_offset:
-                    raise Exception("Operations are expected to be ordered")
+                    raise Exception('Operations are expected to be ordered')
                 old_data_offset = op.data_offset
 
             partition_operations[p.partition_name] = p.operations
 
     db_entry = []
 
-    with open(args.input, "rb") as f_in, output_open(
-        args.output, "wb", args.compress
-    ) as f_out:
+    with open(args.input, 'rb') as f_in, output_open(args.output, 'wb',
+                                                     args.compress) as f_out:
         # Copy zip data until payload.bin + payload.bin header
         output_writer(f_in, f_out, file_offset + blob_offset, db_entry)
 
         # Sort partitions based on data_offset of first operation and iterate
-        for _, p_operations in sorted(
-            partition_operations.items(), key=lambda x: x[1][0].data_offset
-        ):
+        for _, p_operations in sorted(partition_operations.items(),
+                                      key=lambda x: x[1][0].data_offset):
             # Copy all data until first partition offset
             output_writer(
                 f_in,
                 f_out,
-                p_operations[0].data_offset - (f_in.tell() - file_offset - blob_offset),
+                p_operations[0].data_offset -
+                (f_in.tell() - file_offset - blob_offset),
                 db_entry,
             )
 
@@ -232,8 +235,9 @@ def convert_image(args):
                 if op.type == Type.ZERO or op.type == Type.DISCARD:
                     continue
 
-                if f_out.tell() != (file_offset + blob_offset + op.data_offset):
-                    raise Exception("f_out should be equal to the offset")
+                if f_out.tell() != (file_offset + blob_offset +
+                                    op.data_offset):
+                    raise Exception('f_out should be equal to the offset')
                 output_writer(None, f_out, op.data_length, db_entry)
             f_in.seek(f_out.tell())
 
@@ -248,29 +252,31 @@ def convert_image(args):
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(
-        dest="subcommand", required=True, help="Subcommands"
-    )
+    subparsers = parser.add_subparsers(dest='subcommand',
+                                       required=True,
+                                       help='Subcommands')
 
     base = argparse.ArgumentParser(add_help=False)
     base.add_argument(
-        "--compress",
+        '--compress',
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Compress output file",
+        help='Compress output file',
     )
-    base.add_argument("--db", required=True, help="Path to database file")
-    base.add_argument("--output", required=True, help="Path to new OTA zip")
-    base.add_argument("device_name", help="Name of device (as in database)")
+    base.add_argument('--db', required=True, help='Path to database file')
+    base.add_argument('--output', required=True, help='Path to new OTA zip')
+    base.add_argument('device_name', help='Name of device (as in database)')
 
-    convert = subparsers.add_parser(
-        "convert", help="Convert full OTA zip to dummy zip", parents=[base]
-    )
-    convert.add_argument("--input", required=True, help="Path to original OTA zip")
+    convert = subparsers.add_parser('convert',
+                                    help='Convert full OTA zip to dummy zip',
+                                    parents=[base])
+    convert.add_argument('--input',
+                         required=True,
+                         help='Path to original OTA zip')
 
-    subparsers.add_parser(
-        "download", help="Assemble dummy zip while downloading", parents=[base]
-    )
+    subparsers.add_parser('download',
+                          help='Assemble dummy zip while downloading',
+                          parents=[base])
 
     return parser.parse_args(args=args)
 
@@ -278,13 +284,13 @@ def parse_args(args=None):
 def main(args=None):
     args = parse_args(args=args)
 
-    if args.subcommand == "convert":
+    if args.subcommand == 'convert':
         convert_image(args)
-    elif args.subcommand == "download":
+    elif args.subcommand == 'download':
         download_dummy_image(args)
     else:
         raise NotImplementedError()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/tests_ci/test_db.toml
+++ b/tests_ci/test_db.toml
@@ -1,0 +1,65 @@
+[magisk]
+filename = "magisk.apk"
+url = "https://github.com/topjohnwu/Magisk/releases/download/v25.2/Magisk-v25.2.apk"
+sha256 = "0bdc32918b6ea502dca769b1c7089200da51ea1def170824c2812925b426d509"
+
+[device.bluejay]
+filename = "bluejay-ota-tq1a.230205.002-1ec64b58.zip"
+url = "https://dl.google.com/dl/android/aosp/bluejay-ota-tq1a.230205.002-1ec64b58.zip"
+sections = [
+    {range = [0, 25781534], checksum = "2db28a01"},
+    {range = [50595563, 50613918], checksum = "6f0635b4"},
+    {range = [1870236118, 1871590329], checksum = "272a03c1"},
+    {range = [2051986898, 2081231853], checksum = "39940962"}
+]
+
+[device.bluejay.hashes]
+"boot.img" = "8131084ad95d8ffcb917bc239ffdeef6"
+"vbmeta.img" = "38bc2245f6d41877ebf92d6612d3ca04"
+"vendor_boot.img" = "4611f85f4eae65e0eca09605068d14c8"
+
+[device.bramble]
+filename = "bramble-ota-tq1a.230205.002-49f2dc71.zip"
+url = "https://dl.google.com/dl/android/aosp/bramble-ota-tq1a.230205.002-49f2dc71.zip"
+sections = [
+    {range = [0, 12759576], checksum = "b0a1b579"},
+    {range = [1155394531, 1155409742], checksum = "b018de12"},
+    {range = [1636569527, 1637452126], checksum = "b8747c8"},
+    {range = [1870498525, 1896655733], checksum = "f3d4f27b"}
+]
+
+[device.bramble.hashes]
+"boot.img" = "098500dfba880f9a61a379d342a84cc9"
+"vbmeta.img" = "17230bbb41023bd3b03aaf94203e9330"
+"vendor_boot.img" = "34e3559f2460d8ef52ccb5352e09dfec"
+
+[device.cheetah]
+filename = "cheetah-ota-tq1a.230205.002-ad27a6d7.zip"
+url = "https://dl.google.com/dl/android/aosp/cheetah-ota-tq1a.230205.002-ad27a6d7.zip"
+sections = [
+    {range = [0, 23399500], checksum = "34f19830"},
+    {range = [125881702, 125898553], checksum = "9f68fc6d"},
+    {range = [1518207067, 1518293650], checksum = "a003f2d1"},
+    {range = [1883282667, 1883297278], checksum = "9537e70d"},
+    {range = [2010705366, 2012070705], checksum = "94fdddd2"},
+    {range = [2278970391, 2307353441], checksum = "6ba7d418"}
+]
+
+[device.cheetah.hashes]
+"init_boot.img" = "7c200e0dfd1af446d68a3f009cc86f8b"
+"vbmeta.img" = "b12f7e00cc7b9152f7aaa00ab2c4bae0"
+"vendor_boot.img" = "e39682b1656b8c59ac2717f330a08bd9"
+
+[device.sunfish]
+filename = "sunfish-ota-tq1a.230205.002-536bce5f.zip"
+url = "https://dl.google.com/dl/android/aosp/sunfish-ota-tq1a.230205.002-536bce5f.zip"
+sections = [
+    {range = [0, 34269195], checksum = "93177bf6"},
+    {range = [1146499715, 1146513902], checksum = "83903c62"},
+    {range = [1610565619, 1611042042], checksum = "114b64ce"},
+    {range = [1807072291, 1809631036], checksum = "4d33dae2"}
+]
+
+[device.sunfish.hashes]
+"boot.img" = "ddd9bcf0bdc4c727f33110f90103158a"
+"vbmeta.img" = "7388afabde4bb490ddef491dd2a8fe27"

--- a/tests_ci/test_db.toml
+++ b/tests_ci/test_db.toml
@@ -7,13 +7,15 @@ sha256 = "0bdc32918b6ea502dca769b1c7089200da51ea1def170824c2812925b426d509"
 filename = "bluejay-ota-tq1a.230205.002-1ec64b58.zip"
 url = "https://dl.google.com/dl/android/aosp/bluejay-ota-tq1a.230205.002-1ec64b58.zip"
 sections = [
-    {range = [0, 25781534], checksum = "2db28a01"},
-    {range = [50595563, 50613918], checksum = "6f0635b4"},
-    {range = [1870236118, 1871590329], checksum = "272a03c1"},
-    {range = [2051986898, 2081231853], checksum = "39940962"}
+    {range = [0, 139778], checksum = "735aaec5"},
+    {range = [1058270, 21565696], checksum = "6d678822"},
+    {range = [1871582186, 1871586145], checksum = "a2cb908e"},
+    {range = [2051986898, 2074913521], checksum = "cbe90d23"},
+    {range = [2081226738, 2081231853], checksum = "a35c373c"}
 ]
 
 [device.bluejay.hashes]
+"output.zip" = "a180c527edbff9e9b79f2e2ccc69ddc8"
 "boot.img" = "8131084ad95d8ffcb917bc239ffdeef6"
 "vbmeta.img" = "38bc2245f6d41877ebf92d6612d3ca04"
 "vendor_boot.img" = "4611f85f4eae65e0eca09605068d14c8"
@@ -22,13 +24,15 @@ sections = [
 filename = "bramble-ota-tq1a.230205.002-49f2dc71.zip"
 url = "https://dl.google.com/dl/android/aosp/bramble-ota-tq1a.230205.002-49f2dc71.zip"
 sections = [
-    {range = [0, 12759576], checksum = "b0a1b579"},
-    {range = [1155394531, 1155409742], checksum = "b018de12"},
-    {range = [1636569527, 1637452126], checksum = "b8747c8"},
-    {range = [1870498525, 1896655733], checksum = "f3d4f27b"}
+    {range = [0, 139859], checksum = "9f614ee"},
+    {range = [495580, 11663820], checksum = "c693d7bc"},
+    {range = [1637447711, 1637449950], checksum = "3d1b0c8b"},
+    {range = [1870498525, 1893837708], checksum = "363a292b"},
+    {range = [1896650617, 1896655733], checksum = "afa1b25f"}
 ]
 
 [device.bramble.hashes]
+"output.zip" = "1c70967bebee1958e4b48e4fe24804c8"
 "boot.img" = "098500dfba880f9a61a379d342a84cc9"
 "vbmeta.img" = "17230bbb41023bd3b03aaf94203e9330"
 "vendor_boot.img" = "34e3559f2460d8ef52ccb5352e09dfec"
@@ -37,15 +41,16 @@ sections = [
 filename = "cheetah-ota-tq1a.230205.002-ad27a6d7.zip"
 url = "https://dl.google.com/dl/android/aosp/cheetah-ota-tq1a.230205.002-ad27a6d7.zip"
 sections = [
-    {range = [0, 23399500], checksum = "34f19830"},
-    {range = [125881702, 125898553], checksum = "9f68fc6d"},
-    {range = [1518207067, 1518293650], checksum = "a003f2d1"},
-    {range = [1883282667, 1883297278], checksum = "9537e70d"},
-    {range = [2010705366, 2012070705], checksum = "94fdddd2"},
-    {range = [2278970391, 2307353441], checksum = "6ba7d418"}
+    {range = [0, 149481], checksum = "dfe69e7b"},
+    {range = [956810, 21464228], checksum = "20549db1"},
+    {range = [21633246, 23130212], checksum = "2c2a7f0f"},
+    {range = [2012062382, 2012066453], checksum = "ecb6ef7"},
+    {range = [2278970391, 2296636083], checksum = "ca9cb33d"},
+    {range = [2307348326, 2307353441], checksum = "c7d6f505"}
 ]
 
 [device.cheetah.hashes]
+"output.zip" = "43a1bf9feff5acdfade249b7fa4ebe10"
 "init_boot.img" = "7c200e0dfd1af446d68a3f009cc86f8b"
 "vbmeta.img" = "b12f7e00cc7b9152f7aaa00ab2c4bae0"
 "vendor_boot.img" = "e39682b1656b8c59ac2717f330a08bd9"
@@ -54,12 +59,13 @@ sections = [
 filename = "sunfish-ota-tq1a.230205.002-536bce5f.zip"
 url = "https://dl.google.com/dl/android/aosp/sunfish-ota-tq1a.230205.002-536bce5f.zip"
 sections = [
-    {range = [0, 34269195], checksum = "93177bf6"},
-    {range = [1146499715, 1146513902], checksum = "83903c62"},
-    {range = [1610565619, 1611042042], checksum = "114b64ce"},
-    {range = [1807072291, 1809631036], checksum = "4d33dae2"}
+    {range = [0, 128863], checksum = "cb73eb21"},
+    {range = [476024, 34020612], checksum = "996210e5"},
+    {range = [1611037619, 1611039858], checksum = "4b1b2b8b"},
+    {range = [1809626019, 1809631036], checksum = "d7408f3d"}
 ]
 
 [device.sunfish.hashes]
+"output.zip" = "daedbeefd8028879c1d01ddbd61ce469"
 "boot.img" = "ddd9bcf0bdc4c727f33110f90103158a"
 "vbmeta.img" = "7388afabde4bb490ddef491dd2a8fe27"

--- a/tests_ci/test_db.toml
+++ b/tests_ci/test_db.toml
@@ -69,3 +69,21 @@ sections = [
 "output.zip" = "daedbeefd8028879c1d01ddbd61ce469"
 "boot.img" = "ddd9bcf0bdc4c727f33110f90103158a"
 "vbmeta.img" = "7388afabde4bb490ddef491dd2a8fe27"
+
+[device.OnePlus10Pro]
+filename = "6812ccee9a8a891032af1e053e3217731ac7ad92.zip"
+url = ""
+sections = [
+    {range = [0, 201623], checksum = "2acd36ae"},
+    {range = [1196332, 23427210], checksum = "15217bd3"},
+    {range = [25849763, 38696302], checksum = "5cc8ac5f"},
+    {range = [39073011, 39075766], checksum = "21a72228"},
+    {range = [474699863, 490863355], checksum = "1ced0b0b"},
+    {range = [5094768711, 5094772523], checksum = "be0bf45c"}
+]
+
+[device.OnePlus10Pro.hashes]
+"output.zip" = "6d82da4e5b5b072f32df0b14c159897c"
+"boot.img" = "83156961f7a3659dbd5789b0dbfa6a47"
+"recovery.img" = "d443e28da4ebc0b525d11cc20b55cce4"
+"vbmeta.img" = "26502dda312ba05acf250a7973c3afeb"

--- a/tests_ci/test_db.toml
+++ b/tests_ci/test_db.toml
@@ -72,7 +72,7 @@ sections = [
 
 [device.OnePlus10Pro]
 filename = "6812ccee9a8a891032af1e053e3217731ac7ad92.zip"
-url = ""
+url = "https://android.googleapis.com/packages/ota-api/package/6812ccee9a8a891032af1e053e3217731ac7ad92.zip"
 sections = [
     {range = [0, 201623], checksum = "2acd36ae"},
     {range = [1196332, 23427210], checksum = "15217bd3"},

--- a/tests_ci/test_device.py
+++ b/tests_ci/test_device.py
@@ -77,8 +77,6 @@ def test_device(test_file, magisk_file, hashes, workdir, no_test, db, device_nam
         hashes = dict(new_hashes)
 
     if not no_test:
-        os.remove(output_file)
-
         for filename, md5_hash in hashes.items():
             with open(os.path.join(workdir, filename), "rb") as f:
                 assert util.hash_file(f, hashlib.md5()).hexdigest() == md5_hash

--- a/tests_ci/test_device.py
+++ b/tests_ci/test_device.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import argparse
+import contextlib
+import hashlib
+import os
+import sys
+import urllib
+import zipfile
+
+import tomlkit
+
+sys.path.append(os.path.join(sys.path[0], ".."))
+import avbroot.main
+from avbroot import util
+import dummy_image
+
+
+# We intentionally create a zip file with an invalid CRC for the payload.
+# The CRC of the zip will be checked when EOF is reached.
+# Although we never intentionally read all the way to the end, prefetching of a file
+# might lead to read until EOF and triggering the CRC check, which will fail.
+@contextlib.contextmanager
+def monkey_patches():
+    _update_crc = zipfile.ZipExtFile._update_crc
+
+    def _update_crc_new(self, newdata):
+        self._expected_crc = None
+        return _update_crc(self, newdata)
+
+    zipfile.ZipExtFile._update_crc = _update_crc_new
+
+    yield
+
+    zipfile.ZipExtFile._update_crc = _update_crc
+
+
+def test_device(test_file, magisk_file, hashes, workdir, no_test):
+    output_file = os.path.join(workdir, "output.zip")
+    test_key_prefix = os.path.join(
+        sys.path[0], os.pardir, "tests", "keys", "TEST_KEY_DO_NOT_USE_"
+    )
+
+    with monkey_patches():
+        avbroot.main.main(
+            [
+                "patch",
+                "--input",
+                test_file,
+                "--output",
+                output_file,
+                "--magisk",
+                magisk_file,
+                "--privkey-avb",
+                test_key_prefix + "avb.key",
+                "--privkey-ota",
+                test_key_prefix + "ota.key",
+                "--cert-ota",
+                test_key_prefix + "ota.crt",
+            ]
+        )
+
+    avbroot.main.main(
+        [
+            "extract",
+            "--input",
+            output_file,
+            "--directory",
+            workdir,
+        ]
+    )
+
+    if not no_test:
+        os.remove(output_file)
+
+        for filename, md5_hash in hashes.items():
+            with open(os.path.join(workdir, filename), "rb") as f:
+                assert util.hash_file(f, hashlib.md5()).hexdigest() == md5_hash
+            os.remove(os.path.join(workdir, filename))
+
+
+def download_magisk(f_out, url, checksum):
+    sha256_hash = hashlib.sha256()
+
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req) as d:
+        size = d.info()["Content-Length"]
+        util.copyfileobj_n(d, f_out, int(size), hasher=sha256_hash)
+
+    if sha256_hash.hexdigest() != checksum:
+        raise Exception("ERROR: Checksum of Magisk doesn't match")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--device",
+        action="append",
+        required=True,
+        help="Device name to test against",
+    )
+    parser.add_argument("--db", required=True, help="Path to database file")
+    parser.add_argument(
+        "--no-test", action="store_true", help="Don't test and clean in final steps"
+    )
+    parser.add_argument(
+        "--workdir", required=True, help="Path to directory which contains images"
+    )
+
+    return parser.parse_args()
+
+
+def test_main():
+    args = parse_args()
+
+    with open(args.db, "r") as f:
+        database = tomlkit.load(f)
+
+    magisk_file = os.path.join(args.workdir, database["magisk"]["filename"])
+
+    if not os.path.isfile(magisk_file):
+        with open(magisk_file, "wb") as f_out:
+            print("Downloading Magisk...")
+            download_magisk(
+                f_out, database["magisk"]["url"], database["magisk"]["sha256"]
+            )
+
+    for device_name in args.device:
+        device_entry = database.get("device").get(device_name)
+
+        if not device_entry:
+            raise Exception(f"Device {device_name} not found in database")
+
+        test_file = os.path.join(args.workdir, device_entry["filename"])
+
+        if not os.path.isfile(test_file):
+            print(f"No input file found for {device_name}. Downloading now...")
+
+            dummy_image.main(
+                [
+                    "download",
+                    "--no-compress",
+                    "--db",
+                    args.db,
+                    "--output",
+                    test_file,
+                    device_name,
+                ]
+            )
+
+        test_device(
+            test_file,
+            magisk_file,
+            device_entry.get("hashes"),
+            args.workdir,
+            args.no_test,
+        )
+
+
+if __name__ == "__main__":
+    test_main()

--- a/tests_ci/test_device.py
+++ b/tests_ci/test_device.py
@@ -10,23 +10,24 @@ import urllib
 
 import tomlkit
 
-sys.path.append(os.path.join(sys.path[0], ".."))
+sys.path.append(os.path.join(sys.path[0], '..'))
 import avbroot.main
 from avbroot import util
 import dummy_image
 
 
-def test_device(test_file, magisk_file, hashes, workdir, no_test, db, device_name):
-    output_file = os.path.join(workdir, "output.zip")
-    test_key_prefix = os.path.join(
-        sys.path[0], os.pardir, "tests", "keys", "TEST_KEY_DO_NOT_USE_"
-    )
+def test_device(test_file, magisk_file, hashes, workdir, no_test, db,
+                device_name):
+    output_file = os.path.join(workdir, 'output.zip')
+    test_key_prefix = os.path.join(sys.path[0], os.pardir, 'tests', 'keys',
+                                   'TEST_KEY_DO_NOT_USE_')
 
     # We intentionally create a zip file with an invalid CRC for the payload.
     # The CRC of the zip will be checked when EOF is reached.
     # Although we never intentionally read all the way to the end, prefetching of a file
     # might lead to read until EOF and triggering the CRC check, which will fail.
-    with unittest.mock.patch('zipfile.ZipExtFile._update_crc', lambda _, __: None):
+    with unittest.mock.patch('zipfile.ZipExtFile._update_crc',
+                             lambda _, __: None):
         avbroot.main.main([
             'patch',
             '--input',
@@ -43,42 +44,40 @@ def test_device(test_file, magisk_file, hashes, workdir, no_test, db, device_nam
             test_key_prefix + 'ota.crt',
         ])
 
-    avbroot.main.main(
-        [
-            "extract",
-            "--input",
-            output_file,
-            "--directory",
-            workdir,
-        ]
-    )
+    avbroot.main.main([
+        'extract',
+        '--input',
+        output_file,
+        '--directory',
+        workdir,
+    ])
 
     if hashes is None:
-        with open(db, "r") as f:
+        with open(db, 'r') as f:
             toml_db = tomlkit.load(f)
 
         new_hashes = tomlkit.table()
-        with open(os.path.join(workdir, "output.zip"), "rb") as f:
+        with open(os.path.join(workdir, 'output.zip'), 'rb') as f:
             new_hashes.update(
-                {"output.zip": util.hash_file(f, hashlib.md5()).hexdigest()}
-            )
+                {'output.zip': util.hash_file(f, hashlib.md5()).hexdigest()})
 
-        for i in sorted(glob.glob("*.img", root_dir=workdir)):
-            with open(os.path.join(workdir, i), "rb") as f:
-                new_hashes.update({i: util.hash_file(f, hashlib.md5()).hexdigest()})
+        for i in sorted(glob.glob('*.img', root_dir=workdir)):
+            with open(os.path.join(workdir, i), 'rb') as f:
+                new_hashes.update(
+                    {i: util.hash_file(f, hashlib.md5()).hexdigest()})
 
-        toml_db.get("device").get(device_name).append("hashes", new_hashes)
+        toml_db.get('device').get(device_name).append('hashes', new_hashes)
 
-        with open(db, "w") as f:
+        with open(db, 'w') as f:
             tomlkit.dump(toml_db, f)
 
-        print(f"{device_name} hashes are added to the database")
+        print(f'{device_name} hashes are added to the database')
 
         hashes = dict(new_hashes)
 
     if not no_test:
         for filename, md5_hash in hashes.items():
-            with open(os.path.join(workdir, filename), "rb") as f:
+            with open(os.path.join(workdir, filename), 'rb') as f:
                 assert util.hash_file(f, hashlib.md5()).hexdigest() == md5_hash
             os.remove(os.path.join(workdir, filename))
 
@@ -88,7 +87,7 @@ def download_magisk(f_out, url, checksum):
 
     req = urllib.request.Request(url)
     with urllib.request.urlopen(req) as d:
-        size = d.info()["Content-Length"]
+        size = d.info()['Content-Length']
         util.copyfileobj_n(d, f_out, int(size), hasher=sha256_hash)
 
     if sha256_hash.hexdigest() != checksum:
@@ -98,19 +97,19 @@ def download_magisk(f_out, url, checksum):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-d",
-        "--device",
-        action="append",
+        '-d',
+        '--device',
+        action='append',
         required=True,
-        help="Device name to test against",
+        help='Device name to test against',
     )
-    parser.add_argument("--db", required=True, help="Path to database file")
-    parser.add_argument(
-        "--no-test", action="store_true", help="Don't test and clean in final steps"
-    )
-    parser.add_argument(
-        "--workdir", required=True, help="Path to directory which contains images"
-    )
+    parser.add_argument('--db', required=True, help='Path to database file')
+    parser.add_argument('--no-test',
+                        action='store_true',
+                        help="Don't test and clean in final steps")
+    parser.add_argument('--workdir',
+                        required=True,
+                        help='Path to directory which contains images')
 
     return parser.parse_args()
 
@@ -118,45 +117,42 @@ def parse_args():
 def test_main():
     args = parse_args()
 
-    with open(args.db, "r") as f:
+    with open(args.db, 'r') as f:
         database = tomlkit.load(f)
 
-    magisk_file = os.path.join(args.workdir, database["magisk"]["filename"])
+    magisk_file = os.path.join(args.workdir, database['magisk']['filename'])
 
     if not os.path.isfile(magisk_file):
-        with open(magisk_file, "wb") as f_out:
-            print("Downloading Magisk...")
-            download_magisk(
-                f_out, database["magisk"]["url"], database["magisk"]["sha256"]
-            )
+        with open(magisk_file, 'wb') as f_out:
+            print('Downloading Magisk...')
+            download_magisk(f_out, database['magisk']['url'],
+                            database['magisk']['sha256'])
 
     for device_name in args.device:
-        device_entry = database.get("device").get(device_name)
+        device_entry = database.get('device').get(device_name)
 
         if not device_entry:
-            raise Exception(f"Device {device_name} not found in database")
+            raise Exception(f'Device {device_name} not found in database')
 
-        test_file = os.path.join(args.workdir, device_entry["filename"])
+        test_file = os.path.join(args.workdir, device_entry['filename'])
 
         if not os.path.isfile(test_file):
-            print(f"No input file found for {device_name}. Downloading now...")
+            print(f'No input file found for {device_name}. Downloading now...')
 
-            dummy_image.main(
-                [
-                    "download",
-                    "--no-compress",
-                    "--db",
-                    args.db,
-                    "--output",
-                    test_file,
-                    device_name,
-                ]
-            )
+            dummy_image.main([
+                'download',
+                '--no-compress',
+                '--db',
+                args.db,
+                '--output',
+                test_file,
+                device_name,
+            ])
 
         test_device(
             test_file,
             magisk_file,
-            device_entry.get("hashes"),
+            device_entry.get('hashes'),
             args.workdir,
             args.no_test,
             args.db,
@@ -164,5 +160,5 @@ def test_main():
         )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     test_main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py{39,310,311}
+min_version = 3.9
+skip_missing_interpreters = true
+skipsdist = true
+
+[testenv]
+deps =
+    setuptools>=67.4.0 # Can probably be lower, but otherwise CI errors
+    protobuf==3.8.0 # Tested min version
+    lz4==2.1.0 # Tested min version
+    tomlkit==0.8.0 # Tested min version
+commands =
+    python tests_ci/test_device.py --db tests_ci/test_db.toml {posargs:-d bluejay --workdir /dev/shm}


### PR DESCRIPTION
Needs: #68 

Because testing the full OTA images in a CI would involve huge downloads, in this PR I introduce dummy images and a way to test them with tox.

I combined several commits in one PR as otherwise I would have to create a chain of PR's which all depends on each other.

### Dummy images
Dummy images have some of the partitions which we don't care about (product, system, vendor, system_ext and modem) zeroed out. Zeroing these partitions allows them to be compressed very efficiently to somewhere around 70 MB. Because we now know which sections we do and don't need, with a simple mapping we can download only the sections of an image from the server (using the HTTP Range header) and assemble them locally. This creates an invalid zip file (CRC fails) on purpose to maintain the exact details of each zip.

### Test device
This is inspired by your containerized tests. Maybe it can be combined at some point, but for now I've created a new file. This scripts allows you to select a device from the database, download Magisk, download and assemble the dummy images and some tests using the two main commands of avbroot, `patch` and `extract`. It compares the extracted files with the hashes in the database to see if they match. These hashes are identical whether the files are extracted with the full images, or the dummy images. Maybe we can add a dummy hash of the full file as well to see if they at least stay the same between commits.

### Tox
Tox allows us to test easily with different package versions and Python versions. It also makes it easy to implement this in CI later. The current versions of the dependencies are the lowest I can get away with to get avbroot to work with Python 3.9 - Python 3.11. Tox also allows us to easily add linters later, but I'll leave it up to you to decide what style and conventions we should use. Please note that the `min_version` has nothing to do with Python 3.9, but is needed for the inline comments in the deps sections.

I'm not really used to the Pythonic way of doing things, so feel free to bombard it with comments or shoot it off entirely if you don't like the concept.