### PR TITLE
Test all device images in Github Actions

### DIFF
--- a/.github/actions/preload-img-cache/action.yml
+++ b/.github/actions/preload-img-cache/action.yml
@@ -1,0 +1,47 @@
+name: Preload img cache
+inputs:
+  device:
+    description: 'Device name'
+    required: true
+  filename:
+    description: 'Name of file in workdir'
+    required: true
+  test-db-path:
+    description: 'Path to test database'
+    required: true
+outputs:
+  cache-hit:
+    description: 'Did we hit the cache?'
+    value: ${{ steps.cache-img.outputs.cache-hit }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v3
+      id: cache-img
+      with:
+        key: img-${{ inputs.device }}-${{ inputs.filename }}
+        path: |
+          workdir/${{ inputs.filename }}
+    - if: ${{ ! steps.cache-img.outputs.cache-hit }}
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: python3-lz4 python3-protobuf
+    - if: ${{ ! steps.cache-img.outputs.cache-hit }}
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: python3-tomlkit
+    - name: Creating workdir
+      if: ${{ ! steps.cache-img.outputs.cache-hit }}
+      shell: sh
+      run: mkdir -p workdir
+    - name: Downloading device image for ${{ inputs.device }}
+      if: ${{ ! steps.cache-img.outputs.cache-hit }}
+      shell: sh
+      run: |
+        ./tests_ci/dummy_image.py \
+          download \
+          --no-compress \
+          --db ${{ inputs.test-db-path }} \
+          --output workdir/${{ inputs.filename }} \
+          ${{ inputs.device }}

--- a/.github/actions/preload-img-cache/action.yml
+++ b/.github/actions/preload-img-cache/action.yml
@@ -20,7 +20,7 @@ runs:
     - uses: actions/cache@v3
       id: cache-img
       with:
-        key: img-${{ inputs.device }}-${{ inputs.filename }}
+        key: img-${{ hashFiles(inputs.test-db-path) }}-${{ inputs.device }}
         path: |
           workdir/${{ inputs.filename }}
     - if: ${{ ! steps.cache-img.outputs.cache-hit }}

--- a/.github/actions/preload-magisk-cache/action.yml
+++ b/.github/actions/preload-magisk-cache/action.yml
@@ -1,0 +1,27 @@
+name: Preload Magisk
+inputs:
+  hash:
+    description: 'Magisk hash'
+    required: true
+  url:
+    description: 'Magisk URL'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v3
+      id: cache-magisk
+      with:
+        key: magisk-${{ inputs.hash }}
+        path: |
+          workdir/magisk.apk
+    - name: Creating workdir
+      if: ${{ ! steps.cache-magisk.outputs.cache-hit }}
+      shell: sh
+      run: mkdir -p workdir
+    - name: Downloading Magisk
+      if: ${{ ! steps.cache-magisk.outputs.cache-hit }}
+      shell: sh
+      run: |
+        curl -L -o workdir/magisk.apk ${{ inputs.url }}

--- a/.github/actions/preload-magisk-cache/action.yml
+++ b/.github/actions/preload-magisk-cache/action.yml
@@ -1,7 +1,7 @@
 name: Preload Magisk
 inputs:
-  hash:
-    description: 'Magisk hash'
+  cache-key:
+    description: 'Magisk cache-key'
     required: true
   url:
     description: 'Magisk URL'
@@ -13,7 +13,7 @@ runs:
     - uses: actions/cache@v3
       id: cache-magisk
       with:
-        key: magisk-${{ inputs.hash }}
+        key: ${{ inputs.cache-key }}
         path: |
           workdir/magisk.apk
     - name: Creating workdir

--- a/.github/actions/preload-tox-cache/action.yml
+++ b/.github/actions/preload-tox-cache/action.yml
@@ -9,9 +9,9 @@ runs:
   steps:
     - uses: actions/cache@v3
       with:
-        key: tox-${{ inputs.python-version }}-${{ hashFiles('tox.ini') }}
+        key: tox-${{ hashFiles('tox.ini') }}-${{ inputs.python-version }}
         restore-keys: |
-          tox-${{ inputs.python-version }}
+          tox-
         path: |
           .tox/
           ~/.cache/pip

--- a/.github/actions/preload-tox-cache/action.yml
+++ b/.github/actions/preload-tox-cache/action.yml
@@ -1,0 +1,24 @@
+name: Preload tox cache
+inputs:
+  python-version:
+    description: 'Python version'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v3
+      with:
+        key: tox-${{ inputs.python-version }}-${{ hashFiles('tox.ini') }}
+        restore-keys: |
+          tox-${{ inputs.python-version }}
+        path: |
+          .tox/
+          ~/.cache/pip
+    - uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: tox
+    - uses: actions/setup-python@v4
+      with:
+        python-version: |
+          ${{ fromJson('{ "py39": "3.9", "py310": "3.10", "py311": "3.11" }')[inputs.python-version] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       magisk-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
       magisk-url: ${{ steps.load-db.outputs.magisk-url }}
       img-to-cache: ${{ steps.load-db.outputs.img-to-cache }}
-      hit-magisk: ${{ fromJSON(steps.get-magisk-cache.outputs.magisk-hit).total_count != 0 }}
       hit-tox: |
         ${{ contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py39-{0}', steps.get-tox-cache.outputs.tox-hash)) 
           && contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py310-{0}', steps.get-tox-cache.outputs.tox-hash))
@@ -92,19 +91,11 @@ jobs:
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             -f 'key=${{ env.magisk-key }}' \
             /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
-
-  preload-magisk:
-    name: Preload Magisk
-    runs-on: ubuntu-latest
-    needs: setup
-    timeout-minutes: 2
-    if: ${{ ! fromJSON(needs.setup.outputs.hit-magisk) }}
-    steps:
-      - uses: actions/checkout@v3
       - uses: ./.github/actions/preload-magisk-cache
+        if: ${{ fromJSON(steps.get-magisk-cache.outputs.magisk-hit).total_count == 0 }}
         with:
-          cache-key: ${{ needs.setup.outputs.magisk-key }}
-          url: ${{ needs.setup.outputs.magisk-url }}
+          cache-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
+          url: ${{ steps.load-db.outputs.magisk-url }}
 
   preload-img:
     name: Preload device images
@@ -147,7 +138,7 @@ jobs:
   tests:
     name: Run test for ${{ matrix.device }} with ${{ matrix.python }}
     runs-on: ubuntu-latest
-    needs: [setup, preload-magisk, preload-img, preload-tox]
+    needs: [setup, preload-img, preload-tox]
     timeout-minutes: 5
     # Continue on skipped but not on failures or cancels
     if: ${{ always() && ! failure() && ! cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,18 @@ jobs:
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             -f 'key=img-${{ hashFiles(env.test-db-path) }}-' \
             /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
+      - name: Checking for cached magisk apk
+        id: get-magisk-cache
+        env:
+          magisk-key: magisk-${{ hashFiles(env.test-db-path) }}
+        run: |
+          echo "magisk-key=${{ env.magisk-key }}" >> $GITHUB_OUTPUT
+          echo "magisk-hit=$(gh api \
+            --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -f 'key=${{ env.magisk-key }}' \
+            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
       - name: Loading device test database
         id: load-db
         shell: python
@@ -66,18 +78,6 @@ jobs:
             f.write(f"device-db={db['device']}" + '\n')
             f.write(f"device-list={[i for i in db['device']]}" + '\n')
             f.write(f"magisk-url={db['magisk']['url']}" + '\n')
-      - name: Checking for cached magisk apk
-        id: get-magisk-cache
-        env:
-          magisk-key: magisk-${{ hashFiles(env.test-db-path) }}
-        run: |
-          echo "magisk-key=${{ env.magisk-key }}" >> $GITHUB_OUTPUT
-          echo "magisk-hit=$(gh api \
-            --method GET \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=${{ env.magisk-key }}' \
-            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/preload-magisk-cache
         if: ${{ fromJSON(steps.get-magisk-cache.outputs.magisk-hit).total_count == 0 }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,177 @@
+name: CI
+on: push
+
+env:
+  test-db-path: tests_ci/test_db.toml
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: Prepare workflow data
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      # Default
+      contents: read
+      packages: read
+      # Custom, for API cache access
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      device-db: ${{ steps.load-db.outputs.device-db }}
+      device-list: ${{ steps.load-db.outputs.device-list }}
+      magisk-hash: ${{ steps.load-db.outputs.magisk-hash }}
+      magisk-url: ${{ steps.load-db.outputs.magisk-url }}
+      img-to-cache: ${{ steps.load-db.outputs.img-to-cache }}
+      hit-magisk: ${{ fromJSON(steps.get-magisk-cache.outputs.magisk-hit).total_count != 0 }}
+      hit-tox: |
+        ${{ contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py39-{0}', steps.get-tox-cache.outputs.tox-hash)) 
+          && contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py310-{0}', steps.get-tox-cache.outputs.tox-hash))
+          && contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py311-{0}', steps.get-tox-cache.outputs.tox-hash)) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: python3-tomlkit
+      - name: Checking for cached tox environments
+        id: get-tox-cache
+        run: |
+          echo "tox-hit=$(gh api \
+            --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -f 'key=tox-py3' \
+            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
+          echo "tox-hash=${{ hashFiles('tox.ini') }}" >> $GITHUB_OUTPUT
+      - name: Checking for cached device images
+        run: |
+          gh api \
+            --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -f 'key=img-' \
+            /repos/${{ github.repository }}/actions/caches > cache-data.json
+      - name: Loading device test database
+        id: load-db
+        shell: python
+        run: |
+          import json
+          import os
+          import tomlkit
+
+          with open('${{ env.test-db-path }}') as f:
+            db = tomlkit.load(f)
+
+          with open('cache-data.json', 'r') as f:
+            cache_data = json.load(f)
+          
+          cache_names = {'img-' + i + '-' + j['filename']:i for i,j in db['device'].items()}
+          filenames_cached = [i['key'] for i in cache_data.get('actions_caches') or []]
+          filenames_to_cache = list(set(cache_names) - set(filenames_cached))
+          devices_to_cache = [cache_names[i] for i in filenames_to_cache]
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"device-db={db['device']}" + '\n')
+            f.write(f"device-list={[i for i in db['device']]}" + '\n')
+            f.write(f"magisk-hash={db['magisk']['sha256']}" + '\n')
+            f.write(f"magisk-url={db['magisk']['url']}" + '\n')
+            f.write(f"img-to-cache={devices_to_cache}" + '\n')
+      - name: Checking for cached magisk apk
+        id: get-magisk-cache
+        run: |
+          echo "magisk-hit=$(gh api \
+            --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -f 'key=magisk-${{ steps.load-db.outputs.magisk-hash }}' \
+            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
+
+  preload-magisk:
+    name: Preload Magisk
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 2
+    if: ${{ ! fromJSON(needs.setup.outputs.hit-magisk) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/preload-magisk-cache
+        with:
+          hash: ${{ needs.setup.outputs.magisk-hash }}
+          url: ${{ needs.setup.outputs.magisk-url }}
+
+  preload-img:
+    name: Preload device images
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 5
+    if: ${{ needs.setup.outputs.img-to-cache != '[]' }}
+    strategy:
+      matrix:
+        device: ${{ fromJSON(needs.setup.outputs.img-to-cache) }}
+    env:
+      filename: ${{ fromJSON(needs.setup.outputs.device-db)[matrix.device]['filename'] }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ./.github/actions/preload-img-cache
+        with:
+          device: ${{ matrix.device }}
+          filename: ${{ env.filename }}
+          test-db-path: ${{ env.test-db-path }}
+
+  preload-tox:
+    name: Preload tox environments
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 5
+    if: ${{ ! fromJSON(needs.setup.outputs.hit-tox) }}
+    strategy:
+      matrix:
+        python: [py39, py310, py311]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/preload-tox-cache
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Generating tox environment
+        run: tox -e ${{ matrix.python }} --notest
+
+  tests:
+    name: Run test for ${{ matrix.device }} with ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    needs: [setup, preload-magisk, preload-img, preload-tox]
+    timeout-minutes: 5
+    # Continue on skipped but not on failures or cancels
+    if: ${{ always() && ! failure() && ! cancelled() }}
+    strategy:
+      matrix:
+        device: ${{ fromJSON(needs.setup.outputs.device-list) }}
+        python: [py39, py310, py311]
+    env:
+      filename: ${{ fromJSON(needs.setup.outputs.device-db)[matrix.device]['filename'] }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ./.github/actions/preload-magisk-cache
+        with:
+          hash: ${{ needs.setup.outputs.magisk-hash }}
+          url: ${{ needs.setup.outputs.magisk-url }}
+      - uses: ./.github/actions/preload-img-cache
+        with:
+          device: ${{ matrix.device }}
+          filename: ${{ env.filename }}
+          test-db-path: ${{ env.test-db-path }}
+      - uses: ./.github/actions/preload-tox-cache
+        with:
+          python-version: ${{ matrix.python }}
+
+      # Finally run tests
+      - name: Run test for ${{ matrix.device }} with ${{ matrix.python }}
+        run: tox -e ${{ matrix.python }} -- -d ${{ matrix.device }} --db ${{ env.test-db-path }} --workdir workdir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       device-list: ${{ steps.load-db.outputs.device-list }}
       magisk-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
       magisk-url: ${{ steps.load-db.outputs.magisk-url }}
-      img-to-cache: ${{ steps.load-db.outputs.img-to-cache }}
+      hit-img: ${{ steps.get-img-cache.outputs.img-hit }}
       hit-tox: |
         ${{ contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py39-{0}', steps.get-tox-cache.outputs.tox-hash)) 
           && contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py310-{0}', steps.get-tox-cache.outputs.tox-hash))
@@ -48,37 +48,28 @@ jobs:
             /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
           echo "tox-hash=${{ hashFiles('tox.ini') }}" >> $GITHUB_OUTPUT
       - name: Checking for cached device images
+        id: get-img-cache
         run: |
-          gh api \
+          echo "img-hit=$(gh api \
             --method GET \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=img-' \
-            /repos/${{ github.repository }}/actions/caches > cache-data.json
+            -f 'key=img-${{ hashFiles(env.test-db-path) }}-' \
+            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
       - name: Loading device test database
         id: load-db
         shell: python
         run: |
-          import json
           import os
           import tomlkit
 
           with open('${{ env.test-db-path }}') as f:
             db = tomlkit.load(f)
 
-          with open('cache-data.json', 'r') as f:
-            cache_data = json.load(f)
-          
-          cache_names = {'img-' + i + '-' + j['filename']:i for i,j in db['device'].items()}
-          filenames_cached = [i['key'] for i in cache_data.get('actions_caches') or []]
-          filenames_to_cache = list(set(cache_names) - set(filenames_cached))
-          devices_to_cache = [cache_names[i] for i in filenames_to_cache]
-
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f"device-db={db['device']}" + '\n')
             f.write(f"device-list={[i for i in db['device']]}" + '\n')
             f.write(f"magisk-url={db['magisk']['url']}" + '\n')
-            f.write(f"img-to-cache={devices_to_cache}" + '\n')
       - name: Checking for cached magisk apk
         id: get-magisk-cache
         env:
@@ -102,10 +93,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 5
-    if: ${{ needs.setup.outputs.img-to-cache != '[]' }}
+    # Assume that preloading always succesfully cached all images before.
+    # If for some reason only some got cached, on the first run, the cache will not be preloaded
+    # which will result in some being downloaded multiple times when running the tests.
+    if: ${{ fromJSON(needs.setup.outputs.hit-img).total_count == 0 }}
     strategy:
       matrix:
-        device: ${{ fromJSON(needs.setup.outputs.img-to-cache) }}
+        device: ${{ fromJSON(needs.setup.outputs.device-list) }}
     env:
       filename: ${{ fromJSON(needs.setup.outputs.device-db)[matrix.device]['filename'] }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       device-db: ${{ steps.load-db.outputs.device-db }}
       device-list: ${{ steps.load-db.outputs.device-list }}
-      magisk-hash: ${{ steps.load-db.outputs.magisk-hash }}
+      magisk-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
       magisk-url: ${{ steps.load-db.outputs.magisk-url }}
       img-to-cache: ${{ steps.load-db.outputs.img-to-cache }}
       hit-magisk: ${{ fromJSON(steps.get-magisk-cache.outputs.magisk-hit).total_count != 0 }}
@@ -78,17 +78,19 @@ jobs:
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f"device-db={db['device']}" + '\n')
             f.write(f"device-list={[i for i in db['device']]}" + '\n')
-            f.write(f"magisk-hash={db['magisk']['sha256']}" + '\n')
             f.write(f"magisk-url={db['magisk']['url']}" + '\n')
             f.write(f"img-to-cache={devices_to_cache}" + '\n')
       - name: Checking for cached magisk apk
         id: get-magisk-cache
+        env:
+          magisk-key: magisk-${{ hashFiles(env.test-db-path) }}
         run: |
+          echo "magisk-key=${{ env.magisk-key }}" >> $GITHUB_OUTPUT
           echo "magisk-hit=$(gh api \
             --method GET \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=magisk-${{ steps.load-db.outputs.magisk-hash }}' \
+            -f 'key=${{ env.magisk-key }}' \
             /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
 
   preload-magisk:
@@ -101,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/preload-magisk-cache
         with:
-          hash: ${{ needs.setup.outputs.magisk-hash }}
+          cache-key: ${{ needs.setup.outputs.magisk-key }}
           url: ${{ needs.setup.outputs.magisk-url }}
 
   preload-img:
@@ -161,7 +163,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/preload-magisk-cache
         with:
-          hash: ${{ needs.setup.outputs.magisk-hash }}
+          cache-key: ${{ needs.setup.outputs.magisk-key }}
           url: ${{ needs.setup.outputs.magisk-url }}
       - uses: ./.github/actions/preload-img-cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ jobs:
       magisk-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
       magisk-url: ${{ steps.load-db.outputs.magisk-url }}
       hit-img: ${{ steps.get-img-cache.outputs.img-hit }}
-      hit-tox: |
-        ${{ contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py39-{0}', steps.get-tox-cache.outputs.tox-hash)) 
-          && contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py310-{0}', steps.get-tox-cache.outputs.tox-hash))
-          && contains(fromJSON(steps.get-tox-cache.outputs.tox-hit).actions_caches.*.key, format('tox-py311-{0}', steps.get-tox-cache.outputs.tox-hash)) }}
+      hit-tox: ${{ steps.get-tox-cache.outputs.tox-hit }}
     steps:
       - uses: actions/checkout@v3
       - uses: awalsh128/cache-apt-pkgs-action@v1
@@ -44,9 +41,8 @@ jobs:
             --method GET \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=tox-py3' \
+            -f 'key=tox-${{ hashFiles('tox.ini') }}-py3' \
             /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
-          echo "tox-hash=${{ hashFiles('tox.ini') }}" >> $GITHUB_OUTPUT
       - name: Checking for cached device images
         id: get-img-cache
         run: |
@@ -117,7 +113,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 5
-    if: ${{ ! fromJSON(needs.setup.outputs.hit-tox) }}
+    # Assume that preloading always succesfully cached all tox environments before.
+    # If for some reason only some got cached, on the first run, the cache will not be preloaded
+    # which will result in some being downloaded multiple times when running the tests.
+    if: ${{ fromJSON(needs.setup.outputs.hit-tox).total_count == 0 }}
     strategy:
       matrix:
         python: [py39, py310, py311]


### PR DESCRIPTION
Needs: #68 and #69

This PR adds CI for all devices using Github Actions. It at least allows us to automatically test the most used codepaths for all devices in combination with all Python versions. It tries to cache as much as possible to reduce burden on any external parties while at the same time parallelizing as much tests possible.

Maybe it is a bit much to test all images with all supported Python versions, but for now it is still manageable. 

The preloading is only done on the first run or when something changed in the database or `tox.ini`.

The Github cache gets removed after 7 days, but using a scheduled workflow we could keep the caches around for longer if that's desired.

The results of a full initial run can be seen [here](https://github.com/pascallj/avbroot/actions/runs/4284175992/attempts/1) while a subsequent run (where everything is cached) looks like [this](https://github.com/pascallj/avbroot/actions/runs/4284175992/attempts/2).