### PR TITLE
avbroot/ota.py: Remove OnePlus comment about ZERO blocks

### DIFF
--- a/avbroot/ota.py
+++ b/avbroot/ota.py
@@ -101,7 +101,6 @@ def _extract_image(f_payload, f_out, block_size, blob_offset, partition,
             else:
                 raise Exception(f'Unsupported operation: {op.type}')
 
-            # OnePlus OTA payloads don't specify a checksum for ZERO blocks
             if h_data.digest() != op.data_sha256_hash and op.type != Type.ZERO:
                 raise Exception('Expected hash %s, but got %s' %
                                 (h_data.hexdigest(),


### PR DESCRIPTION
There's no OnePlus-specific behavior here. ZERO blocks are supposed to be missing several fields, including data_sha256_hash.