### PR TITLE
tests: Add native Python parallel download implementation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,8 +14,6 @@ For each image listed in the config, the test process will:
 
 ## Running the tests
 
-aria2 must be installed before running the tests. It is used for downloading the OTA images.
-
 To test against all of the device OTA images listed in [`tests.conf`](./tests.conf), run:
 
 ```bash
@@ -23,8 +21,6 @@ python tests/tests.py
 ```
 
 To only run the tests for a specific device, pass in `-d <device>`. This argument can be specified multiple times (eg. `-d GooglePixel7Pro -d GooglePixel6a`).
-
-To pass in extra arguments to `aria2c`, use `-a=<arg>`. This can be used to enable concurrent downloads (eg. `-a=-x4 -a=-s4`).
 
 ## Running the tests in a container
 

--- a/tests/distros/Containerfile.alpine
+++ b/tests/distros/Containerfile.alpine
@@ -1,3 +1,3 @@
 FROM docker.io/library/alpine:3.17
 
-RUN apk add --no-cache aria2 openssl py3-lz4 py3-protobuf
+RUN apk add --no-cache openssl py3-lz4 py3-protobuf

--- a/tests/distros/Containerfile.arch
+++ b/tests/distros/Containerfile.arch
@@ -1,4 +1,4 @@
 FROM docker.io/archlinux/archlinux:latest
 
-RUN pacman --noconfirm -Syu --needed aria2 openssl python-lz4 python-protobuf \
+RUN pacman --noconfirm -Syu --needed openssl python-lz4 python-protobuf \
     && yes | pacman -Scc

--- a/tests/distros/Containerfile.arch-wine
+++ b/tests/distros/Containerfile.arch-wine
@@ -20,7 +20,6 @@ RUN cat /tmp/pacman.additional.conf >> /etc/pacman.conf \
     && rm /tmp/pacman.additional.conf
 
 RUN pacman --noconfirm -Sy \
-        mingw-w64-x86_64-aria2 \
         mingw-w64-x86_64-ca-certificates \
         mingw-w64-x86_64-openssl \
         mingw-w64-x86_64-python \

--- a/tests/distros/Containerfile.debian
+++ b/tests/distros/Containerfile.debian
@@ -1,5 +1,5 @@
 FROM docker.io/library/debian:11
 
 RUN apt-get -y update \
-    && apt-get -y install aria2 openssl python3-lz4 python3-protobuf \
+    && apt-get -y install openssl python3-lz4 python3-protobuf \
     && find /var/cache/apt/archives /var/lib/apt/lists -mindepth 1 -delete

--- a/tests/distros/Containerfile.fedora
+++ b/tests/distros/Containerfile.fedora
@@ -1,4 +1,4 @@
 FROM registry.fedoraproject.org/fedora-toolbox:37
 
-RUN dnf install -y aria2 openssl python3-lz4 python3-protobuf \
+RUN dnf install -y openssl python3-lz4 python3-protobuf \
     && find /var/cache/dnf -mindepth 1 -delete

--- a/tests/distros/Containerfile.opensuse
+++ b/tests/distros/Containerfile.opensuse
@@ -1,4 +1,4 @@
 FROM registry.opensuse.org/opensuse/toolbox:latest
 
-RUN zypper install -y aria2 openssl python3-lz4 python3-protobuf \
+RUN zypper install -y openssl python3-lz4 python3-protobuf \
     && zypper clean -a

--- a/tests/distros/Containerfile.ubuntu
+++ b/tests/distros/Containerfile.ubuntu
@@ -1,5 +1,5 @@
 FROM docker.io/library/ubuntu:22.10
 
 RUN apt-get -y update \
-    && apt-get -y install aria2 openssl python3-lz4 python3-protobuf \
+    && apt-get -y install openssl python3-lz4 python3-protobuf \
     && find /var/cache/apt/archives /var/lib/apt/lists -mindepth 1 -delete

--- a/tests/distros/Containerfile.ubuntu-lts
+++ b/tests/distros/Containerfile.ubuntu-lts
@@ -1,5 +1,5 @@
 FROM docker.io/library/ubuntu:22.04
 
 RUN apt-get -y update \
-    && apt-get -y install aria2 openssl python3-lz4 python3-protobuf \
+    && apt-get -y install openssl python3-lz4 python3-protobuf \
     && find /var/cache/apt/archives /var/lib/apt/lists -mindepth 1 -delete

--- a/tests/downloader.py
+++ b/tests/downloader.py
@@ -1,0 +1,380 @@
+import argparse
+import collections
+import copy
+import dataclasses
+import functools
+import json
+import os
+import queue
+import sys
+import threading
+import time
+import typing
+import urllib.request
+
+# This is a Python adaptation of the parallel downloader written for samfusdl.
+
+MIN_CHUNK_SIZE = 1 * 1024 * 1024  # 1 MiB
+
+DEFAULT_BUF_SIZE = 16384
+DEFAULT_RETRIES = 3
+DEFAULT_THREADS = 4
+DEFAULT_TIMEOUT = 30
+
+
+@dataclasses.dataclass
+@functools.total_ordering
+class Range:
+    start: int
+    end: int
+
+    def __lt__(self, other) -> bool:
+        return (self.start, self.end) < (other.start, other.end)
+
+    def __eq__(self, other) -> bool:
+        return (self.start, self.end) == (other.start, other.end)
+
+    def __bool__(self) -> bool:
+        return self.start < self.end
+
+    def size(self) -> int:
+        return self.end - self.start
+
+
+class DownloadWorker(threading.Thread):
+    '''
+    Thread to download a contiguous range from <url>.
+
+    After each buffer read, the buffer is submitted to <output_queue>. The
+    download continues only after reading a new range end offset from
+    <input_queue>. The controller uses this to interrupt this thread sooner
+    than expected in order to split the work for better resource utilization.
+    '''
+
+    def __init__(self, url: str, range: Range, output_queue: queue.Queue,
+                 buf_size: typing.Optional[int] = None,
+                 timeout: typing.Optional[int] = None):
+        super().__init__()
+
+        self.url = url
+        self.range = copy.copy(range)
+        self.input_queue = queue.Queue()
+        self.output_queue = output_queue
+        self.timeout = DEFAULT_TIMEOUT if timeout is None else timeout
+        self.buf_size = DEFAULT_BUF_SIZE if buf_size is None else buf_size
+
+    def run(self):
+        try:
+            self._download()
+            self.output_queue.put((self.ident, None))
+        except BaseException as e:
+            self.output_queue.put((self.ident, e))
+
+    def _download(self):
+        req = urllib.request.Request(self.url)
+        req.add_header('Range', f'bytes={self.range.start}-{self.range.end}')
+
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            while self.range:
+                n = min(self.buf_size, self.range.size())
+                data = resp.read(n)
+
+                if not data or len(data) != n:
+                    raise EOFError(f'Expected {n} bytes, but downloaded '
+                                   f'{len(data)} bytes in {self.range}')
+
+                self.output_queue.put((self.ident, data))
+
+                new_end = self.input_queue.get()
+                self.range.start += n
+                self.range.end = new_end
+
+
+class DisplayCallback:
+    def progress(self, current, total):
+        raise NotImplementedError()
+
+    def error(self, msg):
+        raise NotImplementedError()
+
+    def finish(self):
+        raise NotImplementedError()
+
+
+class DefaultDisplayCallback(DisplayCallback):
+    def __init__(self, delay_ms=50):
+        self.current = 0
+        self.total = 0
+        self.delay_ms = delay_ms
+        self.last_render = None
+
+    def progress(self, current, total):
+        self.current = current
+        self.total = total
+
+        now = time.perf_counter_ns()
+
+        if self.last_render is None or \
+                (now - self.last_render) / 1_000_000 > self.delay_ms:
+            self._clear_line()
+            self._print(f'{current / 1024 / 1024:.1f} / '
+                        f'{total / 1024 / 1024:.1f} MiB')
+            self.last_render = now
+
+    def error(self, msg):
+        self._clear_line()
+        self._print(msg, end='\n')
+
+    def finish(self):
+        self._clear_line()
+
+    def _print(self, *args, **kwargs):
+        kwargs.setdefault('end', '')
+        kwargs.setdefault('file', sys.stderr)
+        kwargs.setdefault('flush', True)
+        print(*args, **kwargs)
+
+    def _clear_line(self):
+        self._print('\033[2K\r')
+
+
+def _get_content_length(url: str, timeout: typing.Optional[int] = None) -> int:
+    timeout = DEFAULT_TIMEOUT if timeout is None else timeout
+    req = urllib.request.Request(url, method='HEAD')
+
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return int(resp.headers['content-length'])
+
+
+def _download_ranges(f: typing.BinaryIO, url: str, ranges: list[Range],
+                     display: DisplayCallback,
+                     buf_size: typing.Optional[int] = None,
+                     retries: typing.Optional[int] = None,
+                     threads: typing.Optional[int] = None,
+                     timeout: typing.Optional[int] = None):
+    retries = DEFAULT_RETRIES if retries is None else retries
+    threads = DEFAULT_THREADS if threads is None else threads
+
+    workers = {}
+    # This is our own world view of the ranges that each worker should operate
+    # on. The worker's own view of its range will lag behind this until the
+    # next buffer loop cycle. It's fine for some workers' ranges to temporarily
+    # overlap since all file writes happen on the main thread. The worst case
+    # is that two workers download an overlapped range and the same file region
+    # is written twice.
+    worker_ranges = {}
+    output_queue = queue.Queue()
+    error_count = 0
+
+    file_size = _get_content_length(url, timeout=timeout)
+    f.truncate(file_size)
+
+    if not ranges:
+        ranges.append(Range(0, file_size))
+
+    progress = file_size - sum(r.size() for r in ranges)
+
+    remaining = collections.deque(ranges)
+    failed = []
+
+    try:
+        while True:
+            # Spawn new workers
+            while len(workers) < threads:
+                if not remaining and workers:
+                    # No more ranges to download. Split another worker's range.
+                    ident = max(worker_ranges,
+                                key=lambda i: worker_ranges[i].size())
+                    old_range = worker_ranges[ident]
+                    size = old_range.size()
+
+                    if size >= MIN_CHUNK_SIZE:
+                        new_range = Range(old_range.start + size // 2,
+                                          old_range.end)
+                        old_range.end = new_range.start
+
+                        remaining.appendleft(new_range)
+
+                if not remaining:
+                    break
+
+                worker_range = remaining.popleft()
+                worker = DownloadWorker(url, worker_range, output_queue,
+                                        buf_size=buf_size, timeout=timeout)
+                worker.start()
+
+                workers[worker.ident] = worker
+                worker_ranges[worker.ident] = worker_range
+
+            if not workers:
+                # Everything is done
+                break
+
+            ident, result = output_queue.get()
+
+            # Worker completed successfully
+            if result is None:
+                workers[ident].join()
+                del workers[ident]
+                del worker_ranges[ident]
+
+            # Worker failed
+            elif isinstance(result, BaseException):
+                display.error(f'[Worker#{ident}] {result}')
+                error_count += 1
+
+                # Retry range if we haven't failed too many times
+                if error_count < retries:
+                    remaining.appendleft(worker_ranges[ident])
+                else:
+                    failed.append(worker_ranges[ident])
+
+                workers[ident].join()
+                del workers[ident]
+                del worker_ranges[ident]
+
+            # Got a buffer, write it to the file
+            else:
+                f.seek(worker_ranges[ident].start)
+                f.write(result)
+
+                progress += len(result)
+                worker_ranges[ident].start += len(result)
+                workers[ident].input_queue.put(worker_ranges[ident].end)
+
+                display.progress(progress, file_size)
+
+        display.finish()
+
+    except BaseException:
+        # Cancel remaining threads
+        for ident, worker in workers.items():
+            worker.input_queue.put(worker_ranges[ident].start)
+
+        for worker in workers.values():
+            worker.join()
+
+        display.finish()
+
+        raise
+
+    finally:
+        # Mutate the original ranges parameter so that the caller knows which
+        # ranges are still remaining. This includes the not-yet-started,
+        # failed, and previously-in-progress ranges.
+        remaining.extend(failed)
+        remaining.extend(worker_ranges.values())
+
+        ranges.clear()
+        ranges.extend(sorted(remaining))
+
+    if remaining:
+        raise Exception(f'Download failed with {len(remaining)} chunks left '
+                        f'({file_size - progress} bytes)')
+
+
+def _open_or_create(path: os.PathLike[str]) -> typing.BinaryIO():
+    # Python's open() function has no way to open or create a file for both
+    # reading and writing without truncating without TOCTOU issues.
+    return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT, 0o644), 'r+b')
+
+
+def download_ranges(out: os.PathLike[str], url: str,
+                    initial_ranges: typing.Optional[list[Range]],
+                    display: DisplayCallback,
+                    buf_size: typing.Optional[int] = None,
+                    retries: typing.Optional[int] = None,
+                    threads: typing.Optional[int] = None,
+                    timeout: typing.Optional[int] = None):
+    '''
+    Download <url> to <out> with <threads> parallel threads.
+
+    If <initial_ranges> is specified, only those sections of the file will be
+    downloaded. The empty regions are left untouched (i.e. filled with zeroes).
+    A `.state` file is written if the download is interrupted. If the state
+    file exists when this function is called, <initial_ranges> is ignored and
+    the ranges from the state file are used to resume the download.
+    '''
+
+    state_file = f'{out}.state'
+
+    try:
+        with open(state_file, 'r') as f:
+            ranges_json = json.load(f)
+            ranges = [Range(r['start'], r['end']) for r in ranges_json]
+    except FileNotFoundError:
+        ranges = list(initial_ranges) if initial_ranges else []
+
+    try:
+        with _open_or_create(out) as f:
+            _download_ranges(
+                f,
+                url,
+                ranges,
+                display,
+                buf_size=buf_size,
+                retries=retries,
+                threads=threads,
+                timeout=timeout,
+            )
+    finally:
+        if ranges:
+            with open(state_file, 'w') as f:
+                ranges_json = [{'start': r.start, 'end': r.end}
+                               for r in ranges]
+                json.dump(ranges_json, f, indent=4)
+        else:
+            try:
+                os.unlink(state_file)
+            except FileNotFoundError:
+                pass
+
+
+def parse_range(arg: str):
+    start, delim, end = arg.partition('-')
+    if not delim:
+        raise ValueError('Range should be in the form: <start>-<end>')
+
+    start = int(start)
+    end = int(end)
+
+    return Range(start, end)
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-u', '--url', required=True,
+                        help='URL to download')
+    parser.add_argument('-o', '--output', required=True,
+                        help='Output path')
+    parser.add_argument('-r', '--range', action='append', type=parse_range,
+                        help='Half-open range to download ("<start>-<end>")')
+    parser.add_argument('-t', '--threads', default=4, type=int,
+                        help='Number of parallel threads for downloading')
+    parser.add_argument('--buf-size', default=DEFAULT_BUF_SIZE, type=int,
+                        help='Buffer size per download thread')
+    parser.add_argument('--retries', default=DEFAULT_RETRIES, type=int,
+                        help='Maximum retries during download')
+    parser.add_argument('--timeout', default=DEFAULT_THREADS, type=int,
+                        help='Connection timeout in seconds')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    download_ranges(
+        args.output,
+        args.url,
+        args.range,
+        DefaultDisplayCallback(),
+        buf_size=args.buf_size,
+        retries=args.retries,
+        threads=args.threads,
+        timeout=args.timeout,
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR introduces a custom parallel downloader for the tests. It replaces the current use of `aria2c` and can handle parallel downloads of either the entire file or of a list of byte ranges. It can be used as either a module or CLI tool.

Examples:

* Downloading an entire file:

    ```bash
    python tests/download.py \
        -u https://dl.google.com/dl/android/aosp/cheetah-ota-tq1a.230205.002-ad27a6d7.zip \
        -o /tmp/test.zip
    ```

* Downloading specific ranges (and leaving the rest zeroed/untouched):

    ```bash
    python tests/download.py \
        -u https://github.com/topjohnwu/Magisk/releases/download/v25.2/Magisk-v25.2.apk \
        -o /tmp/test.apk \
        -r 0-16 \
        -r 64-96
    ```

On my machine, it's consistently faster than aria2c. This might be because this implementation allows stealing half the work from another thread when a thread completes the download for its range. It never allows the number of threads to fall below the maximum, until the very end when the remaining chunks are less than 1 MiB.

TODO:
- [x] Integrate with `tests/tests.py`
- [ ] Integrate with #69 in the future