### PR TITLE
Use sparse testing images

### DIFF
--- a/.github/actions/preload-img-cache/action.yml
+++ b/.github/actions/preload-img-cache/action.yml
@@ -20,9 +20,14 @@ runs:
     - uses: actions/cache@v3
       id: cache-img
       with:
-        key: img-${{ hashFiles(inputs.test-db-path) }}-${{ inputs.device }}
+        key: img-v2-${{ hashFiles(inputs.test-db-path) }}-${{ inputs.device }}
         path: |
-          workdir/${{ inputs.filename }}
+          workdir/${{ inputs.filename }}-sparse.tar
+    - if: ${{ steps.cache-img.outputs.cache-hit }}
+      name: Extracting image from sparse archive
+      shell: sh
+      run: |
+        tar -C workdir -xf workdir/${{ inputs.filename }}-sparse.tar
     - if: ${{ ! steps.cache-img.outputs.cache-hit }}
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
@@ -45,3 +50,8 @@ runs:
           --db ${{ inputs.test-db-path }} \
           --output workdir/${{ inputs.filename }} \
           ${{ inputs.device }}
+    - if: ${{ ! steps.cache-img.outputs.cache-hit }}
+      name: Creating sparse archive from image
+      shell: sh
+      run: |
+        tar -C workdir --sparse -cf workdir/${{ inputs.filename }}-sparse.tar ${{ inputs.filename }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             --method GET \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=img-${{ hashFiles(env.test-db-path) }}-' \
+            -f 'key=img-v2-${{ hashFiles(env.test-db-path) }}-' \
             /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
       - name: Checking for cached magisk apk
         id: get-magisk-cache

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -60,7 +60,7 @@ def output_open(filename, mode, compress=True):
 
 def output_writer(f_in, f_out, size, db=None):
     if not f_in:
-        util.zero_n(f_out, size)
+        f_out.seek(size, os.SEEK_CUR)
     else:
         crc_hash = None
         mapping = None
@@ -122,7 +122,7 @@ def download_dummy_image(args):
     previous_offset = 0
     with output_open(args.output, 'wb', args.compress) as f_out:
         for section in device_entry['sections']:
-            util.zero_n(f_out, section['range'][0] - previous_offset)
+            f_out.seek(section['range'][0] - previous_offset, os.SEEK_CUR)
             download_file(f_out, device_entry['url'], section)
             previous_offset = section['range'][1] + 1
 

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -38,12 +38,6 @@ def strtobool(val):
 class Crc32Hasher:
     existing_crc32 = None
 
-    def get_checksum(self):
-        return self.existing_crc32
-
-    def set_checksum(self, existing_crc32):
-        self.existing_crc32 = existing_crc32
-
     def update(self, *args, **kwargs):
         if self.existing_crc32:
             args = args + (self.existing_crc32, )
@@ -80,7 +74,7 @@ def output_writer(f_in, f_out, size, db=None):
             # Combine sections if adjacent
             if db and db[-1]['range'][1] == f_out.tell() - 1:
                 entry = db.pop()
-                crc_hash.set_checksum(entry['checksum'])
+                crc_hash.existing_crc32 = entry['checksum']
                 section_start = entry['range'][0]
             else:
                 section_start = f_out.tell()
@@ -92,7 +86,7 @@ def output_writer(f_in, f_out, size, db=None):
         if mapping:
             db.append({
                 'range': [section_start, section_end],
-                'checksum': crc_hash.get_checksum(),
+                'checksum': crc_hash.existing_crc32,
             })
 
 
@@ -108,7 +102,7 @@ def download_file(f_out, url, section):
                            section['range'][1] - section['range'][0] + 1,
                            hasher=crc_hash)
 
-    if crc_hash.get_checksum() != int(section['checksum'], 16):
+    if crc_hash.existing_crc32 != int(section['checksum'], 16):
         raise Exception(
             f"ERROR: Checksum of range {section['range']} doesn't match")
 

--- a/tests_ci/dummy_image.py
+++ b/tests_ci/dummy_image.py
@@ -254,7 +254,7 @@ def parse_args(args=None):
     base.add_argument(
         '--compress',
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help='Compress output file',
     )
     base.add_argument('--db', required=True, help='Path to database file')


### PR DESCRIPTION
As suggested in #70, creating sparse images for testing also works and saves on disk space and therefore also disk lifetime (be careful with your precious SSDs). Especially the Oneplus image is very big (4.8 GiB); this would consume 9.6 GiB during testing. This also comes somewhat close to the limit of 14 GB for the Github Runners. Now it would occupy 100 MiB actual disk space during testing. On top of that, it also makes the workflow faster.

The total workflow run time went down from 37m 50s to 33m 32s during the [Initial run](https://github.com/pascallj/avbroot/actions/runs/4315054599/attempts/1) and from 29m 30s to 26m 40s during a [subsequent run](https://github.com/pascallj/avbroot/actions/runs/4315054599/attempts/2) (and the runners even seem a bit slow at the moment).

Unfortunately the cache action doesn't preserve the 'sparseness' when tarring, so we have to tar the images ourselves first with the `--sparse` argument.

We also have to invalidate the current caches, so a version parameter is added to the caches now.

Finally the compress option is set to do `--no-compress` by default now as it doesn't make much sense anymore. I left it in in case a filesystem doesn't support sparse files.