### PR TITLE
Make cache pre-checks more robust

### DIFF
--- a/.github/actions/preload-magisk-cache/action.yml
+++ b/.github/actions/preload-magisk-cache/action.yml
@@ -13,12 +13,12 @@ runs:
         key: ${{ inputs.cache-key }}
         path: tests/files/magisk
 
-    - if: ${{ ! steps.cache-img.outputs.cache-hit }}
+    - if: ${{ ! steps.cache-magisk.outputs.cache-hit }}
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
         packages: python3-lz4 python3-protobuf
 
-    - if: ${{ ! steps.cache-img.outputs.cache-hit }}
+    - if: ${{ ! steps.cache-magisk.outputs.cache-hit }}
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
         packages: python3-strictyaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
     outputs:
       config-path: ${{ steps.load-config.outputs.config-path }}
       device-list: ${{ steps.load-config.outputs.device-list }}
-      magisk-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
-      img-key-prefix: ${{ steps.get-img-cache.outputs.img-key-prefix }}
-      img-hit: ${{ steps.get-img-cache.outputs.img-hit }}
-      tox-key-prefix: ${{ steps.get-tox-cache.outputs.tox-key-prefix }}
-      tox-hit: ${{ steps.get-tox-cache.outputs.tox-hit }}
+      magisk-key: ${{ steps.cache-keys.outputs.magisk-key }}
+      img-key-prefix: ${{ steps.cache-keys.outputs.img-key-prefix }}
+      img-hit: ${{ steps.get-img-cache.outputs.cache-hit }}
+      tox-key-prefix: ${{ steps.cache-keys.outputs.tox-key-prefix }}
+      tox-hit: ${{ steps.get-tox-cache.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,49 +58,37 @@ jobs:
               f.write(f'config-path={tests.config.CONFIG_PATH}\n')
               f.write(f"device-list={json.dumps(devices)}\n")
 
+      - name: Generating cache keys
+        id: cache-keys
+        run: |
+          {
+            echo "tox-key-prefix=tox-${{ hashFiles('tox.ini') }}-"; \
+            echo "img-key-prefix=img-${{ hashFiles(steps.load-config.outputs.config-path) }}-"; \
+            echo "magisk-key=magisk-${{ hashFiles(steps.load-config.outputs.config-path) }}";
+          } >> $GITHUB_OUTPUT
+
       - name: Checking for cached tox environments
         id: get-tox-cache
-        env:
-          tox-key-prefix: tox-${{ hashFiles('tox.ini') }}-
-        run: |
-          echo "tox-key-prefix=${{ env.tox-key-prefix }}" >> $GITHUB_OUTPUT
-          echo "tox-hit=$(gh api \
-            --method GET \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=${{ env.tox-key-prefix }}' \
-            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
+        uses: pascallj/cache-key-check@v1
+        with:
+          key: ${{ steps.cache-keys.outputs.tox-key-prefix }}
 
       - name: Checking for cached device images
         id: get-img-cache
-        env:
-          img-key-prefix: img-${{ hashFiles(steps.load-config.outputs.config-path) }}-
-        run: |
-          echo "img-key-prefix=${{ env.img-key-prefix }}" >> $GITHUB_OUTPUT
-          echo "img-hit=$(gh api \
-            --method GET \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=${{ env.img-key-prefix }}' \
-            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
+        uses: pascallj/cache-key-check@v1
+        with:
+          key: ${{ steps.cache-keys.outputs.img-key-prefix }}
 
       - name: Checking for cached magisk apk
         id: get-magisk-cache
-        env:
-          magisk-key: magisk-${{ hashFiles(steps.load-config.outputs.config-path) }}
-        run: |
-          echo "magisk-key=${{ env.magisk-key }}" >> $GITHUB_OUTPUT
-          echo "magisk-hit=$(gh api \
-            --method GET \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            -f 'key=${{ env.magisk-key }}' \
-            /repos/${{ github.repository }}/actions/caches)" >> $GITHUB_OUTPUT
+        uses: pascallj/cache-key-check@v1
+        with:
+          key: ${{ steps.cache-keys.outputs.magisk-key }}
 
       - uses: ./.github/actions/preload-magisk-cache
-        if: ${{ fromJSON(steps.get-magisk-cache.outputs.magisk-hit).total_count == 0 }}
+        if: ${{ steps.get-magisk-cache.outputs.cache-hit != 'true' }}
         with:
-          cache-key: ${{ steps.get-magisk-cache.outputs.magisk-key }}
+          cache-key: ${{ steps.cache-keys.outputs.magisk-key }}
 
   preload-img:
     name: Preload device images
@@ -110,7 +98,7 @@ jobs:
     # Assume that preloading always succesfully cached all images before.
     # If for some reason only some got cached, on the first run, the cache will not be preloaded
     # which will result in some being downloaded multiple times when running the tests.
-    if: ${{ fromJSON(needs.setup.outputs.img-hit).total_count == 0 }}
+    if: ${{ needs.setup.outputs.img-hit != 'true' }}
     strategy:
       matrix:
         device: ${{ fromJSON(needs.setup.outputs.device-list) }}
@@ -132,7 +120,7 @@ jobs:
     # Assume that preloading always succesfully cached all tox environments before.
     # If for some reason only some got cached, on the first run, the cache will not be preloaded
     # which will result in some being downloaded multiple times when running the tests.
-    if: ${{ fromJSON(needs.setup.outputs.tox-hit).total_count == 0 }}
+    if: ${{ needs.setup.outputs.tox-hit != 'true' }}
     strategy:
       matrix:
         python: [py39, py310, py311]


### PR DESCRIPTION
As mentioned in #75 there are more [restrictions on restoring the cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) then first anticipated. This makes our current API checks kind of useless. This can be seen in [this](https://github.com/chenxiaolong/avbroot/actions/runs/4337696041/jobs/7573872981) run (which fails for an unrelated reason) where the preloading of the images is skipped during setup but all the caches are missed during the actual tests.

I created [a dedicated Github action](https://github.com/pascallj/cache-key-check) which checks the refs in (hopefully) the correct order to determine if a cache-key would create a cache-hit under the current circumstances without restoring it. There is no documentation yet, but it should work as-is. The order it uses is:

1. Check for exact ref match (`refs/heads/<branch_name>`, `refs/pull/<pr_number>/merge`, `refs/tags/<tag_name>`)
2. Check for match in source branch if PR (`refs/heads/<pr_source_branch_name>`)
3. Check for match in base branch if PR(`refs/heads/<pr_base_branch_name>`)
4. Check for match in default branch (`refs/heads/<default_branch_name>`)

Let's see how this works out in practice. At least it doesn't break anything as can be seen in [run 1](https://github.com/pascallj/avbroot/actions/runs/4339008640/attempts/1) and [run 2](https://github.com/pascallj/avbroot/actions/runs/4339008640/attempts/2).