### PR TITLE
Use `lookup-only` action to check if cache exists

### DIFF
--- a/.github/actions/preload-img-cache/action.yml
+++ b/.github/actions/preload-img-cache/action.yml
@@ -14,6 +14,7 @@ runs:
       id: cache-img
       with:
         key: ${{ inputs.cache-key-prefix }}${{ inputs.device }}
+        # Make sure any changes to path are also reflected in ci.yml setup
         path: tests/files/${{ inputs.device }}-sparse.tar
 
     - if: ${{ steps.cache-img.outputs.cache-hit }}

--- a/.github/actions/preload-magisk-cache/action.yml
+++ b/.github/actions/preload-magisk-cache/action.yml
@@ -11,6 +11,7 @@ runs:
       id: cache-magisk
       with:
         key: ${{ inputs.cache-key }}
+        # Make sure any changes to path are also reflected in ci.yml setup
         path: tests/files/magisk
 
     - if: ${{ ! steps.cache-magisk.outputs.cache-hit }}

--- a/.github/actions/preload-tox-cache/action.yml
+++ b/.github/actions/preload-tox-cache/action.yml
@@ -15,6 +15,7 @@ runs:
         key: ${{ inputs.cache-key-prefix }}${{ inputs.python-version }}
         restore-keys: |
           tox-
+        # Make sure any changes to path are also reflected in ci.yml setup
         path: |
           .tox/
           ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,22 +15,14 @@ jobs:
     name: Prepare workflow data
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    permissions:
-      # Default
-      contents: read
-      packages: read
-      # Custom, for API cache access
-      actions: read
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       config-path: ${{ steps.load-config.outputs.config-path }}
       device-list: ${{ steps.load-config.outputs.device-list }}
       magisk-key: ${{ steps.cache-keys.outputs.magisk-key }}
       img-key-prefix: ${{ steps.cache-keys.outputs.img-key-prefix }}
-      img-hit: ${{ steps.get-img-cache.outputs.cache-hit }}
+      img-hit: ${{ steps.get-img-cache.outputs.cache-matched-key }}
       tox-key-prefix: ${{ steps.cache-keys.outputs.tox-key-prefix }}
-      tox-hit: ${{ steps.get-tox-cache.outputs.cache-hit }}
+      tox-hit: ${{ steps.get-tox-cache.outputs.cache-matched-key }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -69,24 +61,34 @@ jobs:
 
       - name: Checking for cached tox environments
         id: get-tox-cache
-        uses: pascallj/cache-key-check@v1
+        uses: actions/cache/restore@v3
         with:
           key: ${{ steps.cache-keys.outputs.tox-key-prefix }}
+          lookup-only: true
+          path: |
+            .tox/
+            ~/.cache/pip
 
       - name: Checking for cached device images
         id: get-img-cache
-        uses: pascallj/cache-key-check@v1
+        uses: actions/cache/restore@v3
         with:
           key: ${{ steps.cache-keys.outputs.img-key-prefix }}
+          lookup-only: true
+          path: |
+            tests/files/${{ fromJSON(steps.load-config.outputs.device-list)[0] }}-sparse.tar
 
       - name: Checking for cached magisk apk
         id: get-magisk-cache
-        uses: pascallj/cache-key-check@v1
+        uses: actions/cache/restore@v3
         with:
           key: ${{ steps.cache-keys.outputs.magisk-key }}
+          lookup-only: true
+          path: tests/files/magisk
 
-      - uses: ./.github/actions/preload-magisk-cache
-        if: ${{ steps.get-magisk-cache.outputs.cache-hit != 'true' }}
+      - name: Preloading Magisk cache
+        if: ${{ ! steps.get-magisk-cache.outputs.cache-hit }}
+        uses: ./.github/actions/preload-magisk-cache
         with:
           cache-key: ${{ steps.cache-keys.outputs.magisk-key }}
 
@@ -98,7 +100,7 @@ jobs:
     # Assume that preloading always succesfully cached all images before.
     # If for some reason only some got cached, on the first run, the cache will not be preloaded
     # which will result in some being downloaded multiple times when running the tests.
-    if: ${{ needs.setup.outputs.img-hit != 'true' }}
+    if: ${{ ! needs.setup.outputs.img-hit }}
     strategy:
       matrix:
         device: ${{ fromJSON(needs.setup.outputs.device-list) }}
@@ -120,7 +122,7 @@ jobs:
     # Assume that preloading always succesfully cached all tox environments before.
     # If for some reason only some got cached, on the first run, the cache will not be preloaded
     # which will result in some being downloaded multiple times when running the tests.
-    if: ${{ needs.setup.outputs.tox-hit != 'true' }}
+    if: ${{ ! needs.setup.outputs.tox-hit }}
     strategy:
       matrix:
         python: [py39, py310, py311]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
         with:
           submodules: true
 
-      - uses: ./.github/actions/preload-img-cache
+      - name: Preloading image cache
+        uses: ./.github/actions/preload-img-cache
         with:
           cache-key-prefix: ${{ needs.setup.outputs.img-key-prefix }}
           device: ${{ matrix.device }}
@@ -129,7 +130,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/preload-tox-cache
+      - name: Preloading tox cache
+        uses: ./.github/actions/preload-tox-cache
         with:
           cache-key-prefix: ${{ needs.setup.outputs.tox-key-prefix }}
           python-version: ${{ matrix.python }}
@@ -153,16 +155,19 @@ jobs:
         with:
           submodules: true
 
-      - uses: ./.github/actions/preload-magisk-cache
+      - name: Restoring Magisk cache
+        uses: ./.github/actions/preload-magisk-cache
         with:
           cache-key: ${{ needs.setup.outputs.magisk-key }}
 
-      - uses: ./.github/actions/preload-img-cache
+      - name: Restoring image cache
+        uses: ./.github/actions/preload-img-cache
         with:
           cache-key-prefix: ${{ needs.setup.outputs.img-key-prefix }}
           device: ${{ matrix.device }}
 
-      - uses: ./.github/actions/preload-tox-cache
+      - name: Restoring tox cache
+        uses: ./.github/actions/preload-tox-cache
         with:
           cache-key-prefix: ${{ needs.setup.outputs.tox-key-prefix }}
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Now that https://github.com/actions/cache/pull/1041 is merged, we can use the `lookup-only` option, instead of my custom action. This is a much better solution. I didn't expect this to be merged so quickly :see_no_evil:.

The only downside is that the [actions/cache](https://github.com/actions/cache) also checks the version key, which is partly based on the path. So this must be duplicated. Also the `cache-hit` output is only set on a exact match and not on a prefix, so we use `cache-matched-key` instead to see if there is any hit. We were already using this all or nothing solution anyway.