### PR TITLE
Magisk >=25207 require a rules device ID

### DIFF
--- a/avbroot/formats/compression.py
+++ b/avbroot/formats/compression.py
@@ -156,6 +156,7 @@ class CompressedFile:
         fp: typing.BinaryIO,
         mode: typing.Literal['rb', 'wb'] = 'rb',
         format: typing.Optional[Format] = None,
+        raw_if_unknown = False,
     ):
         if mode == 'rb' and not format:
             magic = fp.read(_MAGIC_MAX_SIZE)
@@ -170,6 +171,8 @@ class CompressedFile:
             format_fp = gzip.GzipFile(fileobj=fp, mode=mode, mtime=0)
         elif format == Format.LZ4_LEGACY:
             format_fp = Lz4Legacy(fp, mode)
+        elif raw_if_unknown:
+            format_fp = fp
         else:
             raise ValueError('Unknown compression format')
 

--- a/avbroot/util.py
+++ b/avbroot/util.py
@@ -1,9 +1,43 @@
 import contextlib
+import dataclasses
+import functools
 import os
 import tempfile
 
 
 _ZERO_BLOCK = memoryview(b'\0' * 16384)
+
+
+@dataclasses.dataclass
+@functools.total_ordering
+class Range:
+    '''
+    Simple class to represent a half-open interval.
+    '''
+
+    start: int
+    end: int
+
+    def __repr__(self) -> str:
+        return f'[{self.start}, {self.end})'
+
+    def __str__(self) -> str:
+        return f'>={self.start}, <{self.end}'
+
+    def __lt__(self, other) -> bool:
+        return (self.start, self.end) < (other.start, other.end)
+
+    def __eq__(self, other) -> bool:
+        return (self.start, self.end) == (other.start, other.end)
+
+    def __contains__(self, item) -> bool:
+        return item >= self.start and item < self.end
+
+    def __bool__(self) -> bool:
+        return self.start < self.end
+
+    def size(self) -> int:
+        return self.end - self.start
 
 
 @contextlib.contextmanager

--- a/extra/cpiotool.py
+++ b/extra/cpiotool.py
@@ -78,28 +78,15 @@ def parse_args():
 
 def load_archive(path, **cpio_kwargs):
     with open(path, 'rb') as f_raw:
-        decompressed = False
-
-        try:
-            with compression.CompressedFile(f_raw, 'rb') as f:
-                decompressed = True
-                return cpio.load(f.fp, **cpio_kwargs), f.format
-        except ValueError:
-            # Not the best API
-            if decompressed:
-                raise
-            else:
-                f_raw.seek(0)
-                return cpio.load(f_raw, **cpio_kwargs), None
+        with compression.CompressedFile(f_raw, 'rb', raw_if_unknown=True) as f:
+            return cpio.load(f.fp, **cpio_kwargs), f.format
 
 
 def save_archive(path, entries, format):
     with open(path, 'wb') as f_raw:
-        if format:
-            with compression.CompressedFile(f_raw, 'wb', format=format) as f:
-                cpio.save(f.fp, entries)
-        else:
-            cpio.save(f_raw, entries)
+        with compression.CompressedFile(f_raw, 'wb', format=format,
+                                        raw_if_unknown=True) as f:
+            cpio.save(f.fp, entries)
 
 
 def main():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -211,7 +211,7 @@ def download_image(config_data, device, work_dir, stripped, revalidate):
     if stripped:
         sha256_key = 'stripped'
         image_file += '.stripped'
-        sections = [downloader.Range(s['start'].data, s['end'].data)
+        sections = [util.Range(s['start'].data, s['end'].data)
                     for s in image_config['sections']]
 
     return download(


### PR DESCRIPTION
Newer Magisk versions no longer try to autodetect a writable ext4 partition for storing SELinux rules during boot. Instead, the block device is detected during boot image patching and is stored in the ramdisk's `.backup/.magisk` as `makedev(rdev_maj, rdev_min)`.

This unfortunately complicates the patching process for avbroot. Even if we replicate Magisk's algorithm for finding a suitable partition, there's no way to find the block device's rdev for it with the information contained in the OTA package. This is the first change that adds a hard dependency on information only attainable from a running device.

For these newer Magisk versions, the user will have to patch the boot image once in the Magisk app (must be on the target device) and then run `avbroot magisk-info` to show the computed device ID. Then, avbroot can use this during patching via `--magisk-rules-device`. If the user's device is unable to run the Magisk app prior to patching (eg. unbootable), they'll have to go through the patching process twice, once with `--ignore-magisk-warnings` and a second time with the proper device ID specified.

When using `--ignore-magisk-warnings`, root still works, but there will be subtle issues, like certain modules failing to load.