### PR TITLE
Add support for replacing any partition image

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ Note that avbroot will validate that the prepatched image is compatible with the
 
 avbroot can be used for just resigning an OTA by specifying `--rootless` instead of `--magisk`/`--prepatched`. With this option, the patched OTA will not be rooted. The only modification applied is the replacement of the OTA verification certificate so that the OS can be upgraded with future (patched) OTAs.
 
+### Replacing partitions
+
+avbroot supports replacing entire partitions in the OTA, even partitions that are not boot images (eg. `vendor_dlkm`). A partition can be replaced by passing in `--replace <partition name> /path/to/partition.img`.
+
+The only behavior this changes is where the partition is read from. When using `--replace`, instead of reading the partition image from the original OTA's `payload.bin`, it is read from the specified file. Thus, the replacement partition images must have proper vbmeta footers, like the originals.
+
+This has no impact on what patches are applied. For example, when using Magisk, the root patch is applied to the boot partition, no matter if the partition came from the original `payload.bin` or from `--replace`.
+
 ### Clearing vbmeta flags
 
 Some Android builds may ship with a root `vbmeta` image with the flags set such that AVB is effectively disabled. When avbroot encounters these images, the patching process will fail with a message like:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -13,7 +13,7 @@ import zipfile
 
 sys.path.append(os.path.join(sys.path[0], '..'))
 from avbroot import ota, util
-from avbroot.main import PARTITION_PRIORITIES, PATH_PAYLOAD
+from avbroot.main import get_required_images, PATH_PAYLOAD
 import avbroot.main
 import ota_utils
 import update_metadata_pb2
@@ -27,8 +27,6 @@ TEST_KEY_PASSPHRASE_AVB = \
     'XltUCz36vqCNSzspPZxFMGXah3kLyrTXDwfmasgn6nL4CtZDw5OeeLwlmkDuV2Im'
 TEST_KEY_PASSPHRASE_OTA = \
     '7DsqL2Sk9T609OFpeVXwnrWHRrK3iazccxEDHWDqr5zJ9tgZkONhDvXhXuCQY76o'
-
-PARTITIONS_TO_PRESERVE = set(sum(PARTITION_PRIORITIES.values(), ()))
 
 
 def hash_zeroes(hasher, size):
@@ -111,8 +109,11 @@ def strip_image(input, output):
 
         Type = update_metadata_pb2.InstallOperation.Type
 
+        required_images = get_required_images(manifest, '@gki_ramdisk', True)
+        required_images = set(required_images.values())
+
         for p in manifest.partitions:
-            if p.partition_name not in PARTITIONS_TO_PRESERVE:
+            if p.partition_name not in required_images:
                 for op in p.operations:
                     if op.type == Type.ZERO or op.type == Type.DISCARD:
                         continue

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -9,12 +9,10 @@ device:
     sections:
     - start: 0
       end: 151715
-    - start: 961379
-      end: 21514020
     - start: 21683150
       end: 23179365
     - start: 2043499985
-      end: 2043504053
+      end: 2043508325
     - start: 2315331822
       end: 2333060126
     - start: 2344084950
@@ -22,13 +20,15 @@ device:
     hash:
       original:
         full: 6ac5ff2e14dc16755ea4ea30e6dbe25103b889a36a465194ef943bd0d665b91c
-        stripped: 1834c00a5c7feb7925dc684e93c33707b3b18cac3a2b54a188c571fd18844933
+        stripped: 549522015f0369a3b89385f532ab62235b47c2c39540bd0adaaf6acc81fdda94
       patched:
         full: 7a9d103fd82a034ff349e9684be942b47094de946c13175dd7cacfbd5a2801c0
-        stripped: 337e0d0b2ab4b97a1630b4e7987389526f17d61b24a65e60c2ab7e62a37477a0
+        stripped: a0f74619fc20a3d3d14d1b47247e06aaf801019ab9992f4a4bf97b51c260ecb9
       avb_images:
         init_boot.img: 07b5899a9259e4b054b1184226b07bec634a93933f5092c7f74089cf19dfb352
         vbmeta.img: 903486b11bedb173e5f8ebfff3b80df3f4ac96e9267e98973e9a5c0dfd4a84e3
+        vbmeta_system.img: cf8c77dcf0a4474d49b5bdc2a44bdb3646464d5212fbe12aa5d3c5f531742f4f
+        vbmeta_vendor.img: 660d8f61acd95a4f8ad416b4cbe126e9c039706462b4236ad723953c72ac49a8
         vendor_boot.img: a6746a6d8c8f1229984c063cb7f86198994f913b7f3fbbbac14337ffae15e9f0
 
   # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -40,7 +40,7 @@ device:
     - start: 1060207
       end: 21612852
     - start: 1886150700
-      end: 1886154660
+      end: 1886158844
     - start: 2069112987
       end: 2092260102
     - start: 2098778558
@@ -48,13 +48,15 @@ device:
     hash:
       original:
         full: 915f9087b627b6961be9bb447dc63a7a1083b536753a78715e98641eaeb9c9d1
-        stripped: a56115e71e2c45385591281d287a1cc8a2f94be478f52b8d4f10ed4091733915
+        stripped: a3ee5b6e39e687665c31790118ab9f47715b0b8285ae9847dbf81307f963db14
       patched:
         full: ee904dacf01f340651dc50db9ba3732315ad66cc3147b7c8508017b083db3657
-        stripped: 62a2094b46328059166a404163bfce1ac4d31ac160fb781f1ef6440ed2800a73
+        stripped: dd721a35fe2dac5d258c978eb8b4ce084f455aea21062936bee81761f3b3118d
       avb_images:
         boot.img: 74a7561ee562bf267f1e67243b431cf60538859d5bf7ca624bfc99fe4d425861
         vbmeta.img: 1afe23814943ad79915fdf2c1aac82d53d99587eb8e2966eace106bf966287fa
+        vbmeta_system.img: 285b83e4290f3257dc3678f0c3191794830bb2d72fb0969b69fc8f09d7ddff12
+        vbmeta_vendor.img: 981f736586b91a9f4c93c4208a0d191a35ff15118c6fa505d755ee7fda8b2477
         vendor_boot.img: 68454782e3e5107555b33567a6403a253aa8f63591889ab9c5afe29d03227393
 
   # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -66,7 +68,7 @@ device:
     - start: 496187
       end: 11655082
     - start: 1650283561
-      end: 1650285805
+      end: 1650287993
     - start: 1884739919
       end: 1908081011
     - start: 1910894027
@@ -74,13 +76,14 @@ device:
     hash:
       original:
         full: a925dd09c8d613d46cf72677c16f4fadee18bc21734d57047c6ccf31f672507b
-        stripped: 742a7c2282c684a3699d367ed4fb336f47517434e5702a16e78bf21d62d97580
+        stripped: 79322b0b417359e8f072032de676d7e5bd2715a3b3554c48ed5cc9e9a25c6866
       patched:
         full: 24e83b01a8c17f803e15956ee94476eab398436a49c03377a71fc4cff70bd255
-        stripped: 67fe136a276ef5db9fd54ede3c06becad69fa5ef4af72dd249e3c3729ca37c59
+        stripped: 308fa3da7c2836aa95a37b00b8aed4fab5a7fb0d2a7b3f3d7d2b12444f2b9a3c
       avb_images:
         boot.img: e15eb2ff0609c9d84fef085ef72ccd7523ae4ac2a39082ae917e0402efdfd2f3
         vbmeta.img: 23cb8e2fe74b3a709b49e78808f1d8561c8681700f22f0fda1fd1a9fd198e3c5
+        vbmeta_system.img: 2fcd52d7462916a8510bbb07f2f5a14200afe2de97568396fe75e04c5c283152
         vendor_boot.img: 34901182f5e29d9ab92d5ab0f50fc96b44c6efffaa41c6b380234a92da9a2b10
 
   # What's unique: boot (boot v2)
@@ -92,19 +95,20 @@ device:
     - start: 476996
       end: 34035261
     - start: 1624751947
-      end: 1624754183
+      end: 1624756371
     - start: 1823132563
       end: 1823137581
     hash:
       original:
         full: 174fd16b47ef994ea8f3cb0f3fb456df2654b0aa1f9ea6fb8e54e5c6319f2601
-        stripped: 4a06fb2293aa1f2788a342dea834d71044997bf00c85db10f468b6c758b9d484
+        stripped: 943ce3ae2aac8a0ccd4a7e9d4e38a9c495c39639f2621c6853be4c7a3fa0fc26
       patched:
         full: 928bb6bca12d3b4c9fe7e327855e010632c626df0d18971ad8212b64ef7fe4ba
-        stripped: 8cf8b2bea5049a4d7583dc0c262e27f2b8db92f06340b29730a3749432d4767a
+        stripped: 6cb939f42385b91b1398a6157dc6171a7354a37f3fe4a86752b98ad5a872b8df
       avb_images:
         boot.img: 36d4a348b2ea54655c28a71d14f865eb1181bb860b71057845afeb151d054817
         vbmeta.img: e0923a65c9cd77f2327b43a679524c7945fdc1f9f6cf707b75f7f215dcd852cd
+        vbmeta_system.img: 7cdb590bfc1056a5a8c7606ff05e99eb344efe108296682698b5cfe83905e0cd
 
   # What's unique:
   # - boot (boot v4) + recovery (boot v4)
@@ -124,20 +128,26 @@ device:
       end: 204048
     - start: 19105432
       end: 34966775
+    - start: 2657405750
+      end: 2657407254
     - start: 4984045446
-      end: 5019718276
+      end: 5006377281
     - start: 5114504441
       end: 5114507197
+    - start: 5138158449
+      end: 5138159817
     - start: 5140101511
       end: 5140105324
     hash:
       original:
         full: 929f892fbd70699cf7f118a119aac1ae1b86351e1ada17715666fa4401e63472
-        stripped: 6d9013c29aff5dc07ec549d844c5888089fe65f4a5c624bbd0afa04d1503ec8a
+        stripped: 4eabaf79b6c2b5df305e3ecdc2b9570c0dd27350b4e8d6434584000c4989ff3d
       patched:
         full: c152a9c49a81d521b7652662807d017655cbb999d503f869599753ab907b2133
-        stripped: 799a5135fde9bca972a96fad1c05cd4468c7c55c1c89cc26d0baed1ede31f25e
+        stripped: 15e04f3fcca564384c2258c9a93cd5986d82f5b8b68d08a4e067fa7aae0b3dcc
       avb_images:
         boot.img: ec703e143c24e7eb5b2eb96beb1d4342c1dd2179b12612d41430b1b55e7dec0f
         recovery.img: 2ff62bc52a5900eb170cc44df0f0ee8062ee6dcb48ecf1899ac556145161f53c
         vbmeta.img: c022cf79da301a8430af5c49704944c490707fa0306031fe3ea22c39ce4734f6
+        vbmeta_system.img: 749616b7f04487c05e9e363ad2071a0ab3bae29d497daf1f1a7695f7c8cfa82a
+        vbmeta_vendor.img: a6037fce745384425fb12745b8568386b84fb57ca6f94f6e47bcf754de341ae4


### PR DESCRIPTION
This commit adds support for replacing any partition image within the payload with a custom image. This is useful, for example, to add a custom kernel to an OTA, which may involve partitions that wouldn't normally be touched (eg. `vendor_dlkm`).

Any image specified via `--replace` will have its corresponding descriptor in the vbmeta image updated. This is handled recursively. For example, replacing `vendor_dlkm` would update both `vbmeta_vendor` and `vbmeta`. This requires all vbmeta images to be extracted during the patching process so that a complete dependency graph can be computed. The performance hit in doing so is negligible, but does require the checksums of the stripped images to be updated for the tests.

Fixes: #102