### PR TITLE
Add support for ignoring boot image checks for --prepatched

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ avbroot can replace the boot image with a prepatched image instead of applying t
 
 For KernelSU, also pass in `--boot-partition @gki_kernel` for both the `patch` and `extract` commands. avbroot defaults to Magisk's semantics where the boot image containing the GKI ramdisk is needed, whereas KernelSU requires the boot image containing the GKI kernel. This only affects devices launching with Android 13, where the GKI kernel and ramdisk are in different partitions (`boot` vs. `init_boot`), but it is safe and recommended to always use this option for KernelSU.
 
-Note that avbroot will validate that the prepatched image is compatible with the original. If, for example, the header fields do not match or a boot image section is missing, then the patching process will abort. This check is not foolproof, but should help protect against accidental use of the wrong boot image.
+Note that avbroot will validate that the prepatched image is compatible with the original. If, for example, the header fields do not match or a boot image section is missing, then the patching process will abort. The checks are not foolproof, but should help protect against accidental use of the wrong boot image. To bypass a somewhat "safe" subset of the checks, use `--ignore-prepatched-compat`. To ignore all checks (strongly discouraged!), pass it in twice.
 
 ### Skipping root patches
 

--- a/avbroot/main.py
+++ b/avbroot/main.py
@@ -355,7 +355,11 @@ def patch_subcommand(args):
             else:
                 raise e
     else:
-        root_patch = boot.PrepatchedImage(args.prepatched)
+        root_patch = boot.PrepatchedImage(
+            args.prepatched,
+            args.ignore_prepatched_compat + 1,
+            print_warning,
+        )
 
     # Get passphrases for keys
     passphrase_avb = openssl.prompt_passphrase(
@@ -542,6 +546,12 @@ def parse_args(argv=None):
         action='store_true',
         help='Ignore Magisk compatibility/version warnings',
     )
+    patch.add_argument(
+        '--ignore-prepatched-compat',
+        default=0,
+        action='count',
+        help='Ignore compatibility issues with prepatched boot images',
+    )
 
     patch.add_argument(
         '--clear-vbmeta-flags',
@@ -595,13 +605,17 @@ def parse_args(argv=None):
 
     args = parser.parse_args(args=argv)
 
-    if args.subcommand == 'patch' and args.magisk is None:
-        if args.magisk_preinit_device:
-            parser.error('--magisk-preinit-device requires --magisk')
-        elif args.magisk_random_seed:
-            parser.error('--magisk-random-seed requires --magisk')
-        elif args.ignore_magisk_warnings:
-            parser.error('--ignore-magisk-warnings requires --magisk')
+    if args.subcommand == 'patch':
+        if args.magisk is None:
+            if args.magisk_preinit_device:
+                parser.error('--magisk-preinit-device requires --magisk')
+            elif args.magisk_random_seed:
+                parser.error('--magisk-random-seed requires --magisk')
+            elif args.ignore_magisk_warnings:
+                parser.error('--ignore-magisk-warnings requires --magisk')
+        elif args.prepatched is None:
+            if args.ignore_prepatched_compat:
+                parser.error('--ignore-prepatched-compat requires --prepatched')
 
     return args
 


### PR DESCRIPTION
There are 3 levels of warnings:

* Level 0: Warnings that don't affect booting
  * Mismatched `id` or `os_version` fields
* Level 1: Warnings that may affect booting
  * Mismatched `cmdline` or `extra_cmdline` fields
  * Unexpected addition of `kernel`, `second`, `recovery_dtbo`, `dtb`, or `bootconfig`
* Level 2: Warnings that are very likely to affect booting
  * All other mismatched, added, or removed fields

By default, any warning of level 1 or higher is treated as a fatal error. Each time `--ignore-prepatched-compat` is passed in, the permitted warning level is increased.

Fixes: #108