### PR TITLE
Make output file permissions respect umask

### DIFF
--- a/avbroot/main.py
+++ b/avbroot/main.py
@@ -719,6 +719,8 @@ def parse_args(argv=None):
 def main(argv=None):
     args = parse_args(argv=argv)
 
+    util.load_umask_unsafe()
+
     if args.subcommand == 'patch':
         patch_subcommand(args)
     elif args.subcommand == 'extract':


### PR DESCRIPTION
We have to emulate this with fchmod because Python's NamedTemporaryFile always opens the file descriptor with 600 permissions.