### PR TITLE
Upgrade xz to 5.4.4 and enable all encoders and decoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,8 +926,7 @@ dependencies = [
 [[package]]
 name = "lzma-sys"
 version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+source = "git+https://github.com/chenxiaolong/xz2-rs?rev=fe2050b9c3395db15d8610f1dabb505440c1a556#fe2050b9c3395db15d8610f1dabb505440c1a556"
 dependencies = [
  "cc",
  "libc",
@@ -2268,8 +2267,7 @@ dependencies = [
 [[package]]
 name = "xz2"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+source = "git+https://github.com/chenxiaolong/xz2-rs?rev=fe2050b9c3395db15d8610f1dabb505440c1a556#fe2050b9c3395db15d8610f1dabb505440c1a556"
 dependencies = [
  "lzma-sys",
 ]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -44,7 +44,6 @@ thiserror = "1.0.47"
 toml_edit = { version = "0.19.14", features = ["serde"] }
 topological-sort = "0.2.2"
 x509-cert = { version = "0.2.4", features = ["builder"] }
-xz2 = "0.1.7"
 
 # There's an upstream bug that causes an infinite loop in the write::BzDecoder
 # destructor if the decoder is fed invalid data. While this never happens during
@@ -54,6 +53,14 @@ xz2 = "0.1.7"
 [dependencies.bzip2]
 git = "https://github.com/jongiddy/bzip2-rs"
 rev = "2aefcb4d3634de1df226c73d93f758d65228bb8c"
+
+# The upstream xz2 crate uses an old version of liblzma when compiling with the
+# `static` feature and doesn't enable all of the encoders and decoders. This
+# causes certain payload data to fail to decompress.
+# https://github.com/chenxiaolong/avbroot/issues/138
+[dependencies.xz2]
+git = "https://github.com/chenxiaolong/xz2-rs"
+rev = "fe2050b9c3395db15d8610f1dabb505440c1a556"
 
 # https://github.com/zip-rs/zip/pull/383
 [dependencies.zip]

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,7 @@ deny = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
+    "https://github.com/chenxiaolong/xz2-rs",
     "https://github.com/chenxiaolong/zip",
     "https://github.com/jongiddy/bzip2-rs",
 ]


### PR DESCRIPTION
When using the `xz2/static` feature, the xz2 crate uses a bundled version of xz 5.2 and doesn't enable all of the available encoders and decoders. This prevents certain payload data from being decompressed.

Fixes: #138