### PR TITLE
Add initial honggfuzz fuzzing infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +633,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzz"
+version = "2.1.0"
+dependencies = [
+ "avbroot",
+ "honggfuzz",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +718,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "honggfuzz"
+version = "0.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848e9c511092e0daa0a35a63e8e6e475a3e8f870741448b9f6028d69b142f18e"
+dependencies = [
+ "arbitrary",
+ "lazy_static",
+ "memmap2",
+ "rustc_version",
 ]
 
 [[package]]
@@ -831,6 +857,15 @@ name = "memchr"
 version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1309,6 +1344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1431,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 default-members = ["avbroot"]
-members = ["avbroot", "e2e", "xtask"]
+members = ["avbroot", "e2e", "fuzz", "xtask"]
 resolver = "2"
 
 [workspace.package]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+/hfuzz_target/
+HONGGFUZZ.REPORT.TXT
+*.honggfuzz.cov
+*.fuzz

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fuzz"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# There's currently no good way to exclude a workspace member for a specific
+# platform, so we just compile empty stubs on Windows (which isn't supported by
+# honggfuzz).
+# https://github.com/rust-lang/cargo/issues/5220
+# https://github.com/rust-lang/cargo/issues/6179
+[target.'cfg(unix)'.dependencies]
+avbroot = { path = "../avbroot" }
+honggfuzz = "0.5.55"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,53 @@
+# Fuzzing
+
+While avbroot's parsers are all memory-safe, it is still possible for panics or crashes to occur, for example due to excessive memory allocation, integer overflow, or division by zero. Fuzzing helps to identify these issues by randomizing inputs in a way that tries to increase code coverage.
+
+## Running the fuzzers
+
+1. Install the cargo honggfuzz commands.
+
+    ```bash
+    cargo install honggfuzz
+    ```
+
+2. Pick a fuzz target to run. A fuzz target is the name of the source file in [`src/bin/`](./src/bin) without the `.rs` extension.
+
+    The list of targets can be queried programmatically with:
+
+    ```bash
+    cargo read-manifest | jq -r '.targets[].name'
+    ```
+
+3. Run the fuzzer.
+
+    ```bash
+    cargo hfuzz run <fuzz target>
+    ```
+
+    This will run forever until it is manually killed. At the top of the screen, a summary section like the following is shown:
+
+    ```
+      Iterations : 31,243 [31.24k]
+      Mode [1/3] : Feedback Driven Dry Run [2486/4085]
+          Target : hfuzz_target/x86_64-unknown-linux-gnu/release/bootimage
+         Threads : 8, CPUs: 16, CPU%: 800% [50%/CPU]
+           Speed : 36,126/sec [avg: 31,243]
+         Crashes : 53 [unique: 1, blocklist: 0, verified: 0]
+        Timeouts : 0 [1 sec]
+     Corpus Size : 1,424, max: 24,576 bytes, init: 4,085 files
+      Cov Update : 0 days 00 hrs 00 mins 00 secs ago
+        Coverage : edge: 897/224,621 [0%] pc: 2 cmp: 34,736
+    ```
+
+    When a crash occurs, the `Crashes` counter will increment and the input data that triggered the crash will be written to `hfuzz_workspace/<fuzz target>/*.fuzz`. New files are only written for unique crashes.
+
+4. If a crash occurs, run the following command to trigger the crash in a debugger.
+
+    ```bash
+    cargo hfuzz run-debug <fuzz target> \
+        hfuzz_workspace/<fuzz_target>/<input file>.fuzz
+    ```
+
+    This defaults to using `rust-lldb`. To use `rust-gdb` instead, set the `HFUZZ_DEBUGGER` environment variable to `rust-gdb`.
+
+    Alternatively, just feed the input file to the appropriate avbroot command directly (eg. `avbroot boot info -i hfuzz_workspace/<fuzz_target>/<input file>.fuzz` for boot images).

--- a/fuzz/hfuzz_workspace/avb/input/vbmeta_appended_hash.img
+++ b/fuzz/hfuzz_workspace/avb/input/vbmeta_appended_hash.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/vbmeta_appended_hash.img

--- a/fuzz/hfuzz_workspace/avb/input/vbmeta_appended_hash_tree.img
+++ b/fuzz/hfuzz_workspace/avb/input/vbmeta_appended_hash_tree.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/vbmeta_appended_hash_tree.img

--- a/fuzz/hfuzz_workspace/avb/input/vbmeta_root.img
+++ b/fuzz/hfuzz_workspace/avb/input/vbmeta_root.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/vbmeta_root.img

--- a/fuzz/hfuzz_workspace/bootimage/input/boot_v0.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/boot_v0.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/boot_v0.img

--- a/fuzz/hfuzz_workspace/bootimage/input/boot_v1.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/boot_v1.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/boot_v1.img

--- a/fuzz/hfuzz_workspace/bootimage/input/boot_v2.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/boot_v2.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/boot_v2.img

--- a/fuzz/hfuzz_workspace/bootimage/input/boot_v3.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/boot_v3.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/boot_v3.img

--- a/fuzz/hfuzz_workspace/bootimage/input/boot_v4.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/boot_v4.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/boot_v4.img

--- a/fuzz/hfuzz_workspace/bootimage/input/boot_v4_vts.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/boot_v4_vts.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/boot_v4_vts.img

--- a/fuzz/hfuzz_workspace/bootimage/input/vendor_v3.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/vendor_v3.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/vendor_v3.img

--- a/fuzz/hfuzz_workspace/bootimage/input/vendor_v4.img
+++ b/fuzz/hfuzz_workspace/bootimage/input/vendor_v4.img
@@ -1,0 +1,1 @@
+../../../../avbroot/tests/data/vendor_v4.img

--- a/fuzz/src/bin/avb.rs
+++ b/fuzz/src/bin/avb.rs
@@ -1,0 +1,21 @@
+#[cfg(not(windows))]
+mod fuzz {
+    use std::io::Cursor;
+
+    use avbroot::format::avb;
+    use honggfuzz::fuzz;
+
+    pub fn main() {
+        loop {
+            fuzz!(|data: &[u8]| {
+                let reader = Cursor::new(data);
+                let _ = avb::load_image(reader);
+            });
+        }
+    }
+}
+
+fn main() {
+    #[cfg(not(windows))]
+    fuzz::main();
+}

--- a/fuzz/src/bin/bootimage.rs
+++ b/fuzz/src/bin/bootimage.rs
@@ -1,0 +1,21 @@
+#[cfg(not(windows))]
+mod fuzz {
+    use std::io::Cursor;
+
+    use avbroot::{format::bootimage::BootImage, stream::FromReader};
+    use honggfuzz::fuzz;
+
+    pub fn main() {
+        loop {
+            fuzz!(|data: &[u8]| {
+                let reader = Cursor::new(data);
+                let _ = BootImage::from_reader(reader);
+            });
+        }
+    }
+}
+
+fn main() {
+    #[cfg(not(windows))]
+    fuzz::main();
+}


### PR DESCRIPTION
This initially includes fuzzers for the AVB and boot image parsers. The initial input corpus are the same test files we use for the round trip tests.

Issue: #160