### PR TITLE
boot: Rename header.toml to boot.toml for consistency

### DIFF
--- a/README.extra.md
+++ b/README.extra.md
@@ -68,7 +68,7 @@ By default, this command will not write to any file and fails if an image is cor
 avbroot boot unpack -i <input boot image>
 ```
 
-This subcommand unpacks all of the components of the boot image into the current directory by default (see `--help`). The header fields are saved to `header.toml` and each blob section is saved to a separate file. Each blob is written to disk as-is, without decompression.
+This subcommand unpacks all of the components of the boot image into the current directory by default (see `--help`). The header fields are saved to `boot.toml` and each blob section is saved to a separate file. Each blob is written to disk as-is, without decompression.
 
 ### Packing a boot image
 

--- a/avbroot/src/cli/boot.rs
+++ b/avbroot/src/cli/boot.rs
@@ -334,7 +334,7 @@ struct UnpackCli {
     input: PathBuf,
 
     /// Path to output header TOML.
-    #[arg(long, value_name = "FILE", value_parser, default_value = "header.toml")]
+    #[arg(long, value_name = "FILE", value_parser, default_value = "boot.toml")]
     output_header: PathBuf,
 
     /// Path to output kernel image.
@@ -394,7 +394,7 @@ struct PackCli {
     output: PathBuf,
 
     /// Path to input header TOML.
-    #[arg(long, value_name = "FILE", value_parser, default_value = "header.toml")]
+    #[arg(long, value_name = "FILE", value_parser, default_value = "boot.toml")]
     input_header: PathBuf,
 
     /// Path to input kernel image.

--- a/avbroot/src/format/bootimage.rs
+++ b/avbroot/src/format/bootimage.rs
@@ -1255,6 +1255,7 @@ impl<W: Write> ToWriter<W> for VendorBootImageV3Through4 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type")]
 pub enum BootImage {
     V0Through2(BootImageV0Through2),
     V3Through4(BootImageV3Through4),


### PR DESCRIPTION
This also changes the serialization to use a `type` field instead of spewing the enum variant name everywhere.