### PR TITLE
Move reopen functionality to a new trait

### DIFF
--- a/avbroot/src/cli/fec.rs
+++ b/avbroot/src/cli/fec.rs
@@ -53,7 +53,7 @@ fn write_fec(path: &Path, fec: &FecImage) -> Result<()> {
 fn generate_subcommand(cli: &GenerateCli, cancel_signal: &AtomicBool) -> Result<()> {
     let input = open_input(&cli.input, false)?;
 
-    let fec = FecImage::generate(|| Ok(Box::new(input.reopen())), cli.parity, cancel_signal)
+    let fec = FecImage::generate(&input, cli.parity, cancel_signal)
         .context("Failed to generate FEC data")?;
 
     write_fec(&cli.fec, &fec)?;
@@ -65,7 +65,7 @@ fn verify_subcommand(cli: &VerifyCli, cancel_signal: &AtomicBool) -> Result<()> 
     let input = open_input(&cli.input, false)?;
     let fec = read_fec(&cli.fec)?;
 
-    fec.verify(|| Ok(Box::new(input.reopen())), cancel_signal)
+    fec.verify(&input, cancel_signal)
         .context("Failed to verify data")?;
 
     Ok(())
@@ -78,12 +78,8 @@ fn repair_subcommand(cli: &RepairCli, cancel_signal: &AtomicBool) -> Result<()> 
     // The separate buffered readers and writers are safe because the function
     // guarantees that every thread touches disjoint offsets and every offset is
     // read and written at most once.
-    fec.repair(
-        || Ok(Box::new(input.reopen())),
-        || Ok(Box::new(input.reopen())),
-        cancel_signal,
-    )
-    .context("Failed to repair file")?;
+    fec.repair(&input, &input, cancel_signal)
+        .context("Failed to repair file")?;
 
     Ok(())
 }

--- a/avbroot/tests/avb.rs
+++ b/avbroot/tests/avb.rs
@@ -138,10 +138,7 @@ fn round_trip_appended_hash_tree_image() {
 
     // Verify the hash tree and FEC data.
     match header.appended_descriptor().unwrap() {
-        AppendedDescriptorRef::HashTree(d) => {
-            d.verify(|| Ok(Box::new(reader.reopen())), &cancel_signal)
-                .unwrap();
-        }
+        AppendedDescriptorRef::HashTree(d) => d.verify(&reader, &cancel_signal).unwrap(),
         AppendedDescriptorRef::Hash(_) => panic!("Expected hash tree descriptor"),
     }
 
@@ -166,12 +163,7 @@ fn round_trip_appended_hash_tree_image() {
             d.fec_offset = 0;
             d.fec_size = 0;
 
-            d.update(
-                || Ok(Box::new(writer.reopen())),
-                || Ok(Box::new(writer.reopen())),
-                &cancel_signal,
-            )
-            .unwrap();
+            d.update(&writer, &writer, &cancel_signal).unwrap();
         }
         AppendedDescriptorMut::Hash(_) => panic!("Expected hash tree descriptor"),
     }

--- a/e2e/src/download.rs
+++ b/e2e/src/download.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use avbroot::stream::PSeekFile;
+use avbroot::stream::{PSeekFile, Reopen};
 use serde::{Deserialize, Serialize};
 
 /// Minimum download chunk size per task.
@@ -309,7 +309,8 @@ fn download_ranges(
                 }
 
                 if let Some(thread_range) = remaining.pop_front() {
-                    let file_cloned = file.reopen();
+                    // PSeekFile's reopen can't fail.
+                    let file_cloned = file.reopen().unwrap();
                     let thread_range_cloned = thread_range.clone();
                     let tx_cloned = tx.clone();
 

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -27,7 +27,7 @@ use avbroot::{
     cli::ota::{ExtractCli, PatchCli, VerifyCli},
     format::{ota, payload::PayloadHeader},
     protobuf::chromeos_update_engine::install_operation::Type,
-    stream::{self, FromReader, HashingReader, PSeekFile, SectionReader},
+    stream::{self, FromReader, HashingReader, PSeekFile, Reopen, SectionReader},
 };
 use clap::Parser;
 use tempfile::TempDir;
@@ -98,7 +98,7 @@ fn strip_image(
     let mut raw_reader = File::open(input)
         .map(PSeekFile::new)
         .with_context(|| format!("Failed to open for reading: {input:?}"))?;
-    let mut zip_reader = ZipArchive::new(BufReader::new(raw_reader.reopen()))
+    let mut zip_reader = ZipArchive::new(BufReader::new(raw_reader.reopen()?))
         .with_context(|| format!("Failed to read zip: {input:?}"))?;
     let payload_entry = zip_reader
         .by_name(ota::PATH_PAYLOAD)
@@ -108,7 +108,7 @@ fn strip_image(
 
     // Open the payload data directly.
     let mut payload_reader = SectionReader::new(
-        BufReader::new(raw_reader.reopen()),
+        BufReader::new(raw_reader.reopen()?),
         payload_offset,
         payload_size,
     )?;

--- a/fuzz/src/bin/fec.rs
+++ b/fuzz/src/bin/fec.rs
@@ -23,7 +23,7 @@ mod fuzz {
                         input.write_zeros_exact(fec.data_size).unwrap();
                     }
 
-                    let _ = fec.verify(|| Ok(Box::new(input.reopen())), &cancel_signal);
+                    let _ = fec.verify(&input, &cancel_signal);
                 }
             });
         }


### PR DESCRIPTION
This is still not the ideal API, but it makes the code quite a bit more readable since we no longer have to pass around closures everywhere that multithreaded reads and writes to the same file are needed.