### PR TITLE
cli/ota: Fine tune `is_critical_to_avb()` for odm partition

### DIFF
--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -271,11 +271,12 @@ fn load_vbmeta_images(
 /// partitions may be equally important, but it's infeasible to list them all.
 fn is_critical_to_avb(name: &str) -> bool {
     name.ends_with("boot")
-        || name.starts_with("odm")
+        || name.ends_with("dlkm")
         || name.starts_with("system")
         || name.starts_with("vbmeta")
         || name.starts_with("vendor")
         || name == "dtbo"
+        || name == "odm"
         || name == "product"
         || name == "pvmfw"
         || name == "recovery"


### PR DESCRIPTION
AOSP primarily cares about `odm` and `odm_dlkm`, so update the logic to check for that specifically. This fixes patching some OTAs that include an unprotected OEM-specific `odm_ext` image.

Issue: #218