### PR TITLE
cli/ota: Add new --otacerts-partition option for the patch subcommand

### DIFF
--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -117,7 +117,7 @@ fn strip_image(
         .context("Failed to load OTA payload header")?;
 
     let required_images =
-        avbroot::cli::ota::get_required_images(&header.manifest, "@gki_ramdisk", true)?
+        avbroot::cli::ota::get_required_images(&header.manifest, Some("@gki_ramdisk"), None)?
             .into_values()
             .collect::<HashSet<_>>();
     let mut data_holes = vec![];


### PR DESCRIPTION
The autodetection logic for `@otacerts` is based on the presence of the `recovery`, `vendor_boot`, and `boot` partitions (in that order). Some devices have `vendor_boot`, but put `system/etc/security/otacerts.zip` inside `boot`.

With the way things are written now, we don't have the ability to inspect the actual partition images for the autodetection. It is based on the name only. So, for now, we'll just allow the user to override the autodetected partition similar to what we already do with the `--boot-partition` option.

Issue: #218