### PR TITLE
fec: Add support for partially updating FEC data

### DIFF
--- a/README.extra.md
+++ b/README.extra.md
@@ -175,6 +175,14 @@ The default behavior is to use 2 bytes of parity information per 253 bytes of in
 
 The number of parity bytes (between 2 and 24, inclusive) can be configured using `--parity`.
 
+### Updating FEC data
+
+```bash
+avbroot fec update -i <input data file> -f <output FEC file> [-r <start> <end>]...
+```
+
+This will update the FEC data corresponding to the specified regions. This can be significantly faster than generating new FEC data from scratch for large files if the regions where data was modified are known.
+
 ### Verifying a file
 
 ```bash

--- a/avbroot/src/util.rs
+++ b/avbroot/src/util.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-use std::{fmt, path::Path};
+use std::{fmt, ops::Range, path::Path};
 
 use num_traits::PrimInt;
 
@@ -57,4 +57,28 @@ pub fn div_ceil<T: PrimInt>(dividend: T, divisor: T) -> T {
         } else {
             T::zero()
         }
+}
+
+/// Sort and merge overlapping intervals.
+pub fn merge_overlapping<T>(sections: &[Range<T>]) -> Vec<Range<T>>
+where
+    T: Ord + Clone + Copy,
+{
+    let mut sections = sections.to_vec();
+    sections.sort_by_key(|r| (r.start, r.end));
+
+    let mut result = Vec::<Range<T>>::new();
+
+    for section in sections {
+        if let Some(last) = result.last_mut() {
+            if section.start <= last.end {
+                last.end = last.end.max(section.end);
+                continue;
+            }
+        }
+
+        result.push(section);
+    }
+
+    result
 }


### PR DESCRIPTION
FEC data can be updated efficiently with "round" granularity when the regions where the input file was modified are known.