### PR TITLE
avb: hashtree: Fix incorrect I/O read size for input smaller than one block

### DIFF
--- a/avbroot/src/format/avb.rs
+++ b/avbroot/src/format/avb.rs
@@ -475,7 +475,7 @@ impl HashTreeDescriptor {
         // Small files are hashed directly, exactly like a hash descriptor.
         if image_size <= u64::from(block_size) {
             let mut reader = input.reopen_boxed()?;
-            let mut buf = vec![0u8; block_size as usize];
+            let mut buf = vec![0u8; image_size as usize];
             reader.read_exact(&mut buf)?;
 
             let mut context = Context::new(algorithm);


### PR DESCRIPTION
This isn't something we'd ever run into in practice because Android only puts real filesystems inside dm-verity and a real filesystem can't be smaller than one block.