### PR TITLE
Add support for replacing otacerts.zip in the system image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64",
+ "bitflags 2.4.1",
  "bstr",
  "byteorder",
  "bzip2",

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Having a good understanding of how AVB and A/B OTAs work is recommended prior to
 
 ## Patches
 
-avbroot applies two patches to the boot images:
+avbroot applies the following patches to the partition images:
 
 * The `boot` or `init_boot` image, depending on device, is patched to enable root access. For Magisk, the patch is equivalent to what would be normally done by the Magisk app.
 
 * The `boot`, `recovery`, or `vendor_boot` image, depending on device, is patched to replace the OTA signature verification certificates with the custom OTA signing certificate. This allows future patched OTAs to be sideloaded from recovery mode after the bootloader has been locked. It also prevents accidental flashing of the original unpatched OTA.
+
+* The `system` or `my_engineering` image, depending on device, is also patched to replace the OTA signature verification certificates. This prevents the OS' system updater app from installing an unpatched OTA and also allows the use of custom OTA updater apps.
 
 ## Warnings and Caveats
 
@@ -218,22 +220,22 @@ To stop using avbroot and revert to the stock firmware:
 
 4. That's it! There are no other remnants to clean up.
 
-## avbroot modules
+## OTA updates
 
-avbroot's Magisk/KernelSU modules can be downloaded from the [releases page](https://github.com/chenxiaolong/avbroot/releases).
+avbroot replaces `/system/etc/security/otacerts.zip` in both the system and recovery partitions with a new zip that contains the custom OTA signing certificate. This prevents an unpatched OTA from inadvertently being installed both when booted into Android and when sideloading from recovery.
 
-### `clearotacerts`: Block OTA Updates from default updater app
-
-Unpatched OTA updates are already blocked when booted into recovery mode because the original OTA certificate has been replaced with the custom certificate. However, this doesn't prevent the Android's system updater app from attempting to install an unpatched OTA update.
-
-Disabling the system updater app is recommended. To do so:
+Disabling the system updater app is recommended to prevent it from even attempting to install an unpatched OTA. To do so:
 
 * Stock OS: Turn off `Automatic system updates` in Android's Developer Options.
 * Custom OS: Disable the system updater app (or block its network access) from Settings -> Apps -> See all apps -> (three-dot menu) -> Show system -> (find updater app).
 
-As an extra safety measure, flashing the `clearotacerts` module will intentionally make OTAs fail to install while booted into Android. It does so by overriding `/system/etc/security/otacerts.zip` with an empty zip containing no certificates so that even if an OTA is downloaded, signature verification will fail. This may cause some custom OS' system updater app to get stuck in an infinite loop downloading an OTA update and then retrying when signature verification fails, so make sure the system updater app is disabled.
+This is especially important for some custom OS's because their system updater app may get stuck in an infinite loop downloading an OTA update and then retrying when signature verification fails.
 
-As an alternative to this module, see [Custota](https://github.com/chenxiaolong/Custota) for a custom OTA updater app that installs updates from a self-hosted OTA server.
+To self-host a custom OTA server, see [Custota](https://github.com/chenxiaolong/Custota).
+
+## avbroot modules
+
+avbroot's Magisk/KernelSU modules can be downloaded from the [releases page](https://github.com/chenxiaolong/avbroot/releases).
 
 ### `oemunlockonboot`: Enable OEM unlocking on every boot
 

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.75"
 base64 = "0.21.3"
+bitflags = "2.4.1"
 bstr = "1.6.2"
 byteorder = "1.4.3"
 cap-std = "2.0.0"

--- a/avbroot/src/cli/avb.rs
+++ b/avbroot/src/cli/avb.rs
@@ -195,7 +195,7 @@ fn write_raw_and_update(
         AppendedDescriptorMut::HashTree(d) => {
             d.hash_algorithm = promote_insecure_hash_algorithm(&d.hash_algorithm).to_owned();
             d.image_size = image_size;
-            d.update(&raw_file, &raw_file, cancel_signal)
+            d.update(&raw_file, &raw_file, None, cancel_signal)
                 .context("Failed to update hash tree descriptor")?;
         }
         AppendedDescriptorMut::Hash(d) => {
@@ -642,7 +642,7 @@ fn repack_subcommand(cli: &RepackCli, cancel_signal: &AtomicBool) -> Result<()> 
         // There could have been errors in the original FEC data itself.
         if let AppendedDescriptorMut::HashTree(d) = info.header.appended_descriptor_mut()? {
             d.hash_algorithm = promote_insecure_hash_algorithm(&d.hash_algorithm).to_owned();
-            d.update(&file, &file, cancel_signal)?;
+            d.update(&file, &file, None, cancel_signal)?;
         }
 
         update_dm_verity_cmdline(&mut info)?;

--- a/avbroot/src/format/hashtree.rs
+++ b/avbroot/src/format/hashtree.rs
@@ -27,7 +27,6 @@ use crate::{
     util::{self, NumBytes},
 };
 
-// TODO: io::Error
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Hash tree should have size {expected} for input size {input}, but has size {actual}")]

--- a/avbroot/src/format/ota.rs
+++ b/avbroot/src/format/ota.rs
@@ -40,7 +40,7 @@ const NAME_PAYLOAD_METADATA: &str = "payload_metadata.bin";
 pub const PF_NAME: &str = "ota-property-files";
 pub const PF_STREAMING_NAME: &str = "ota-streaming-property-files";
 
-const ZIP_EOCD_MAGIC: &[u8; 4] = b"PK\x05\x06";
+pub const ZIP_EOCD_MAGIC: &[u8; 4] = b"PK\x05\x06";
 
 const COMMENT_MESSAGE: &[u8] = b"signed by avbroot\0";
 

--- a/avbroot/src/lib.rs
+++ b/avbroot/src/lib.rs
@@ -13,12 +13,12 @@
 // We use pb-rs' nostd mode. See build.rs.
 extern crate alloc;
 
-pub mod boot;
 pub mod cli;
 pub mod crypto;
 pub mod escape;
 pub mod format;
 pub mod octal;
+pub mod patch;
 pub mod protobuf;
 pub mod stream;
 pub mod util;

--- a/avbroot/src/patch/mod.rs
+++ b/avbroot/src/patch/mod.rs
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+pub mod boot;
+pub mod otacert;
+pub mod system;

--- a/avbroot/src/patch/otacert.rs
+++ b/avbroot/src/patch/otacert.rs
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+use std::{borrow::Cow, cmp::Ordering, io::Cursor};
+
+use bitflags::bitflags;
+use thiserror::Error;
+use x509_cert::{der::asn1::BitString, Certificate};
+use zip::{result::ZipError, write::FileOptions, CompressionMethod, ZipWriter};
+
+use crate::{crypto, format::ota};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("New otacerts.zip is too small to pad to {0} bytes")]
+    ZipTooSmall(usize),
+    #[error("New otacerts.zip is too large to fit in {0} bytes")]
+    ZipTooLarge(usize),
+    #[error("Crypto error")]
+    Crypto(#[from] crypto::Error),
+    #[error("x509 DER error")]
+    Der(#[from] x509_cert::der::Error),
+    #[error("Zip error")]
+    Zip(#[from] ZipError),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Pad a non-zip64 zip file to the specified size by adding null bytes to the
+/// archive comment field.
+fn pad_zip(data: &mut Vec<u8>, size: usize) -> Result<()> {
+    match size.cmp(&data.len()) {
+        Ordering::Equal => Ok(()),
+        Ordering::Less => Err(Error::ZipTooLarge(size)),
+        Ordering::Greater => {
+            let padding = size - data.len();
+
+            if data.len() < 22
+                || &data[data.len() - 22..][..4] != ota::ZIP_EOCD_MAGIC
+                || padding > usize::from(u16::MAX)
+            {
+                return Err(Error::ZipTooSmall(size));
+            }
+
+            // Rewrite the comment size and pad with null bytes.
+            data.pop();
+            data.pop();
+            data.extend((padding as u16).to_le_bytes());
+            data.resize(size, 0);
+
+            Ok(())
+        }
+    }
+}
+
+bitflags! {
+    /// Android uses X.509 as nothing more than a file format to transport RSA
+    /// public keys. This is true for both the framework's RecoverySystem and
+    /// recovery's otautil/verifier.cpp. The only fields that must exist are
+    /// the public key and the signature algorithm. The rest can be removed with
+    /// no side effects whatsoever.
+    #[derive(Debug, Clone, Copy)]
+    pub struct OtaCertBuildFlags: u8 {
+        const COMPRESS_DEFLATE = 1 << 0;
+        const REMOVE_SIGNATURE = 1 << 1;
+        const REMOVE_EXTENSIONS = 1 << 2;
+        const REMOVE_ISSUER = 1 << 3;
+        const REMOVE_SUBJECT = 1 << 4;
+    }
+}
+
+/// Create an `otacerts.zip` file containing the specified certificate.
+pub fn create_zip(cert: &Certificate, flags: OtaCertBuildFlags) -> Result<Vec<u8>> {
+    let raw_writer = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(raw_writer);
+
+    let compression_method = if flags.contains(OtaCertBuildFlags::COMPRESS_DEFLATE) {
+        CompressionMethod::Deflated
+    } else {
+        CompressionMethod::Stored
+    };
+
+    let options = FileOptions::default().compression_method(compression_method);
+    writer.start_file("ota.x509.pem", options)?;
+
+    let cert = if flags.is_empty() {
+        Cow::Borrowed(cert)
+    } else {
+        let mut modified = cert.clone();
+
+        if flags.contains(OtaCertBuildFlags::REMOVE_SIGNATURE) {
+            modified.signature = BitString::from_bytes(&[])?;
+        }
+        if flags.contains(OtaCertBuildFlags::REMOVE_EXTENSIONS) {
+            if let Some(extensions) = &mut modified.tbs_certificate.extensions {
+                extensions.clear();
+            }
+        }
+        if flags.contains(OtaCertBuildFlags::REMOVE_ISSUER) {
+            modified.tbs_certificate.issuer.0.clear();
+            modified.tbs_certificate.issuer_unique_id = None;
+        }
+        if flags.contains(OtaCertBuildFlags::REMOVE_SUBJECT) {
+            modified.tbs_certificate.subject.0.clear();
+            modified.tbs_certificate.subject_unique_id = None;
+        }
+
+        Cow::Owned(modified)
+    };
+
+    crypto::write_pem_cert(&mut writer, &cert)?;
+
+    let raw_writer = writer.finish()?;
+
+    Ok(raw_writer.into_inner())
+}
+
+/// Create an `otacerts.zip` file padded to the specified size.
+///
+/// This will incrementally remove unneeded components from the certificate to
+/// meet the size limit if needed.
+pub fn create_zip_with_size(cert: &Certificate, size: usize) -> Result<Vec<u8>> {
+    let mut flags = OtaCertBuildFlags::empty();
+
+    for additional_flag in [
+        OtaCertBuildFlags::empty(),
+        OtaCertBuildFlags::COMPRESS_DEFLATE,
+        OtaCertBuildFlags::REMOVE_SIGNATURE,
+        OtaCertBuildFlags::REMOVE_EXTENSIONS,
+        OtaCertBuildFlags::REMOVE_ISSUER,
+        OtaCertBuildFlags::REMOVE_SUBJECT,
+    ] {
+        flags |= additional_flag;
+
+        let mut data = create_zip(cert, flags)?;
+        if data.len() <= size {
+            pad_zip(&mut data, size)?;
+            return Ok(data);
+        }
+    }
+
+    Err(Error::ZipTooLarge(size))
+}

--- a/avbroot/src/patch/system.rs
+++ b/avbroot/src/patch/system.rs
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+use std::{
+    io::{self, Cursor, SeekFrom},
+    ops::Range,
+    sync::atomic::AtomicBool,
+};
+
+use memchr::memmem;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rsa::RsaPrivateKey;
+use thiserror::Error;
+use x509_cert::Certificate;
+use zip::ZipArchive;
+
+use crate::{
+    format::{
+        avb::{self, AppendedDescriptorMut},
+        ota,
+    },
+    patch::otacert,
+    stream::{self, ReadSeekReopen, SectionReader, WriteSeekReopen},
+    util,
+};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Old otacerts.zip not found in image")]
+    OldZipNotFound,
+    #[error("Image has no vbmeta footer")]
+    NoFooter,
+    #[error("No hash tree descriptor found in vbmeta header")]
+    NoHashTreeDescriptor,
+    #[error("AVB error")]
+    Avb(#[from] avb::Error),
+    #[error("OTA certificate error")]
+    OtaCert(#[from] otacert::Error),
+    #[error("I/O error")]
+    Io(#[from] io::Error),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Find the bounds of a non-zip64 zip starting from the EOCD magic offset.
+fn find_zip_bounds(data: &[u8], eocd_offset: usize) -> Option<Range<usize>> {
+    let eocd = &data[eocd_offset..];
+    if eocd.len() < 22 {
+        return None;
+    }
+
+    let cd_size = u32::from_le_bytes(eocd[12..16].try_into().unwrap()) as usize;
+    let cd_offset = u32::from_le_bytes(eocd[16..20].try_into().unwrap()) as usize;
+    let comment_size = usize::from(u16::from_le_bytes(eocd[20..22].try_into().unwrap()));
+
+    let start = eocd_offset.checked_sub(cd_size)?.checked_sub(cd_offset)?;
+    let end = eocd_offset.checked_add(22)?.checked_add(comment_size)?;
+    if end > data.len() {
+        return None;
+    }
+
+    let reader = SectionReader::new(Cursor::new(data), start as u64, (end - start) as u64).ok()?;
+    let mut zip_reader = ZipArchive::new(reader).ok()?;
+
+    if zip_reader.is_empty() {
+        // otacerts.zip files contain at least one cert.
+        return None;
+    }
+
+    for index in 0..zip_reader.len() {
+        let entry = zip_reader.by_index_raw(index).ok()?;
+
+        if !entry.name().ends_with(".x509.pem") {
+            // otacerts.zip files only contain files named this way.
+            return None;
+        }
+    }
+
+    // There's one or more entries and every one is named *.x509.pem.
+    Some(start..end)
+}
+
+/// Replace `otacerts.zip` with a new one containing the new certificate, but
+/// padded to the same size. If the new zip is too large, the certificate will
+/// be modified to remove unnecessary components until it fits. All operations
+/// run in parallel where possible. The input and output must refer to the same
+/// file and will be reopened from multiple threads.
+///
+/// If [`Error::OldZipNotFound`] is returned, the output will not have been
+/// modified.
+pub fn patch_system_image(
+    input: &(dyn ReadSeekReopen + Sync),
+    output: &(dyn WriteSeekReopen + Sync),
+    certificate: &Certificate,
+    key: &RsaPrivateKey,
+    cancel_signal: &AtomicBool,
+) -> Result<Vec<Range<u64>>> {
+    // This must be a multiple of normal filesystem block sizes (eg. 4 KiB).
+    // This ensures that the block containing otacerts.zip's data won't cross
+    // chunk boundaries.
+    const CHUNK_SIZE: u64 = 2 * 1024 * 1024;
+
+    let (mut header, footer, image_size) = avb::load_image(input.reopen_boxed()?)?;
+    let Some(mut footer) = footer else {
+        return Err(Error::NoFooter);
+    };
+    let AppendedDescriptorMut::HashTree(descriptor) = header.appended_descriptor_mut()? else {
+        return Err(Error::NoHashTreeDescriptor);
+    };
+
+    let num_chunks = util::div_ceil(footer.original_image_size, CHUNK_SIZE);
+
+    let modified_ranges = (0..num_chunks)
+        .into_par_iter()
+        .map(|chunk| -> Result<Vec<Range<u64>>> {
+            stream::check_cancel(cancel_signal)?;
+
+            let offset = chunk * CHUNK_SIZE;
+            let size = CHUNK_SIZE.min(footer.original_image_size - offset);
+            let mut buf = vec![0u8; size as usize];
+
+            let mut reader = input.reopen_boxed()?;
+            reader.seek(SeekFrom::Start(offset))?;
+            reader.read_exact(&mut buf)?;
+
+            let mut writer = output.reopen_boxed()?;
+            let mut ranges = Vec::<Range<u64>>::new();
+
+            for eocd_offset_rel in memmem::find_iter(&buf, ota::ZIP_EOCD_MAGIC) {
+                let Some(bounds_rel) = find_zip_bounds(&buf, eocd_offset_rel) else {
+                    continue;
+                };
+
+                let zip_size = bounds_rel.end - bounds_rel.start;
+                let new_zip = otacert::create_zip_with_size(certificate, zip_size)?;
+
+                let bounds = offset + bounds_rel.start as u64..offset + bounds_rel.end as u64;
+
+                stream::check_cancel(cancel_signal)?;
+
+                writer.seek(SeekFrom::Start(bounds.start))?;
+                writer.write_all(&new_zip)?;
+
+                ranges.push(bounds);
+            }
+
+            Ok(ranges)
+        })
+        .try_reduce(Vec::new, |mut result, item| {
+            result.extend(item);
+            Ok(result)
+        })?;
+
+    if modified_ranges.is_empty() {
+        return Err(Error::OldZipNotFound);
+    }
+
+    let update_ranges = if descriptor.hash_algorithm == "sha1" {
+        // Promote to a secure algorithm. SHA1 is allowed for verification only.
+        // The entire hash tree and FEC data will need to be recomputed.
+        descriptor.hash_algorithm = "sha256".to_owned();
+        None
+    } else {
+        // Only need to update the hash tree and FEC data corresponding to the
+        // modified regions.
+        Some(modified_ranges.as_slice())
+    };
+
+    descriptor.update(input, output, update_ranges, cancel_signal)?;
+
+    if !header.public_key.is_empty() {
+        header.set_algo_for_key(key)?;
+        header.sign(key)?;
+    }
+
+    let writer = output.reopen_boxed()?;
+    avb::write_appended_image(writer, &header, &mut footer, image_size)?;
+
+    Ok(modified_ranges)
+}

--- a/avbroot/tests/avb.rs
+++ b/avbroot/tests/avb.rs
@@ -163,7 +163,7 @@ fn round_trip_appended_hash_tree_image() {
             d.fec_offset = 0;
             d.fec_size = 0;
 
-            d.update(&writer, &writer, &cancel_signal).unwrap();
+            d.update(&writer, &writer, None, &cancel_signal).unwrap();
         }
         AppendedDescriptorMut::Hash(_) => panic!("Expected hash tree descriptor"),
     }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -96,7 +96,7 @@ fn strip_image(
     let header = PayloadHeader::from_reader(&mut payload_reader)
         .context("Failed to load OTA payload header")?;
 
-    let required_images = RequiredImages::new(&header.manifest);
+    let required_images = RequiredImages::new(&header.manifest, false);
     let required_images = required_images.iter().collect::<HashSet<_>>();
     let mut data_holes = vec![];
 
@@ -386,6 +386,9 @@ fn patch_image(
         input_file.as_os_str().into(),
         "--output".into(),
         output_file.as_os_str().into(),
+        // We currently don't test patching the system image because it's too
+        // large to do all the time in the CI pipelines.
+        "--skip-system-otacerts".into(),
     ];
     args.extend(key_args);
     args.extend_from_slice(extra_args);
@@ -412,6 +415,7 @@ fn extract_image(input_file: &Path, output_dir: &Path, cancel_signal: &AtomicBoo
         input_file.as_os_str(),
         OsStr::new("--directory"),
         output_dir.as_os_str(),
+        OsStr::new("--skip-system"),
     ])?;
     avbroot::cli::ota::extract_subcommand(&cli, cancel_signal)?;
 

--- a/modules/clearotacerts/module.prop
+++ b/modules/clearotacerts/module.prop
@@ -1,6 +1,0 @@
-id=com.chiller3.avbroot.clearotacerts
-name=clearotacerts
-version=v2.3.3
-versionCode=131843
-author=chenxiaolong
-description=Block A/B OTAs by clearing verification certificates

--- a/xtask/src/module.rs
+++ b/xtask/src/module.rs
@@ -49,12 +49,6 @@ fn newest_child_by_name(directory: &Path) -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("{directory:?} has no children"))
 }
 
-fn build_empty_zip(writer: &mut dyn Write) -> Result<()> {
-    let mut writer = ZipWriter::new_streaming(writer);
-    writer.finish()?;
-    Ok(())
-}
-
 fn build_dex(writer: &mut dyn Write, sources: &[&Path]) -> Result<()> {
     let sdk = env::var_os("ANDROID_HOME")
         .map(PathBuf::from)
@@ -183,10 +177,6 @@ pub fn modules_subcommand(cli: &ModulesCli) -> Result<()> {
         let (path, mut writer) = start_module(&dist_dir, &common_dir, &module_dir)?;
 
         match module {
-            Module::ClearOtaCerts => {
-                writer.start_file("system/etc/security/otacerts.zip", FileOptions::default())?;
-                build_empty_zip(&mut writer)?;
-            }
             Module::OemUnlockOnBoot => {
                 writer.start_file("classes.dex", FileOptions::default())?;
                 build_dex(&mut writer, &[&module_dir.join("Main.java")])?;
@@ -209,7 +199,6 @@ pub fn modules_subcommand(cli: &ModulesCli) -> Result<()> {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "lower")]
 enum Module {
-    ClearOtaCerts,
     OemUnlockOnBoot,
 }
 


### PR DESCRIPTION
Previously, overriding `otacerts.zip` in the system partition required the user to flash a Magisk/KernelSU module that would bind mount over the file during boot. While this worked well enough, it's insufficient for unrooted setups, which has become more important since unrooting is the only safe way to use the new OEM repair mode feature. With the stock `otacerts.zip`, the OEM's default OTA updater app could run and install an OS upgrade that's not signed by the user's key.

With this commit, the raw `otacerts.zip` bytes in the system partition are directly replaced with a new zip that contains the user's certificate. This method was inspired by @pascallj's comment in #216 suggesting intentionally corrupting the `otacerts.zip` data in the filesystem.

Because avbroot does not have filesystem parsers for ext4/f2fs/erofs, we rely on a heuristic-based search on the raw filesystem image. The file is always smaller than one block (which is at least 4096 bytes on all known devices), so the file data is stored contiguously on disk and in the case of erofs, won't be compressed. None of the three filesystems are copy-on-write and thus, have no filesystem-level data checksums. For the dm-verity layer one level up, avbroot already knows how to recompute the hash tree and FEC data.

To ensure that there are no false positives, any match that the search finds must correctly parse as a valid zip and every entry within the zip must have a filename that ends in `.x509.pem`. This matches what `update_engine` expects from a proper `otacerts.zip` file.

Since the new approach is doing a raw search and replace, the old and new files must have the same size. When the new zip is smaller, null bytes are added to the zip archive comment field to pad to the correct size. When the new zip is larger, avbroot will attempt the following to try and make the file size smaller:

1. Enable zip deflate compression
2. Strip the X.509 signature from the certificate
3. Clear out the issuer RDN sequence from the certificate
4. Clear out the subject RDN sequence from the certificate

The latter three changes work because Android never performs any PKI operations with the certificate. There is no CA certificate chain. The X.509 certificate file is nothing more than a way to transport an RSA public key.

avbroot requires the user's key to be RSA 4096. If the original zip had the same key size, then none of these shrinking methods are needed. If it contained an RSA 2048 key, then the first two modifications are usually sufficient. The latter two modifications should only be needed if the user picked a really long subject value when generating the certificate.

With these new changes, the OTA patching time will approximately double on a system with an SSD and modern CPU. This is dominated by the time it takes to XZ-compress the system partition image. The compression is already parallelized and scales linearly with the number of cores. There's likely not much more that can be done to further speed this up.

Finally, these new changes are currently excluded from the e2e tests because including the system partition in the stripped OTAs would increase the file size by an order of magnitude. This could potentially be solved in the future by generating our own small OTAs to use for testing instead of running against real device OTAs.

Fixes: #225