### PR TITLE
Optimize repacking of modified system image into payload

### DIFF
--- a/avbroot/src/util.rs
+++ b/avbroot/src/util.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-use std::{fmt, ops::Range, path::Path};
+use std::{cmp::Ordering, fmt, ops::Range, path::Path};
 
 use num_traits::PrimInt;
 
@@ -83,4 +83,71 @@ where
     }
 
     result
+}
+
+/// Binary search to determine if the needle overlaps any of the ranges.
+pub fn ranges_overlaps<T>(ranges: &[Range<T>], needle: &Range<T>) -> bool
+where
+    T: Ord,
+{
+    if needle.start < needle.end {
+        ranges
+            .binary_search_by(|range| {
+                if range.start > needle.end {
+                    Ordering::Greater
+                } else if range.end <= needle.start {
+                    Ordering::Less
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .is_ok()
+    } else {
+        false
+    }
+}
+
+/// Binary search to determine if any of the ranges contain the needle.
+pub fn ranges_contains<T>(ranges: &[Range<T>], needle: &T) -> bool
+where
+    T: Ord,
+{
+    ranges
+        .binary_search_by(|range| {
+            if range.start > *needle {
+                Ordering::Greater
+            } else if range.end <= *needle {
+                Ordering::Less
+            } else {
+                Ordering::Equal
+            }
+        })
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ranges_overlaps() {
+        assert_eq!(ranges_overlaps(&[0..4], &(0..0)), false);
+        assert_eq!(ranges_overlaps(&[0..4], &(0..4)), true);
+        assert_eq!(ranges_overlaps(&[0..4], &(1..4)), true);
+        assert_eq!(ranges_overlaps(&[0..4], &(0..3)), true);
+        assert_eq!(ranges_overlaps(&[0..4], &(4..5)), false);
+        assert_eq!(ranges_overlaps(&[5..8], &(5..9)), true);
+        assert_eq!(ranges_overlaps(&[5..8], &(4..8)), true);
+        assert_eq!(ranges_overlaps(&[5..8], &(4..9)), true);
+        assert_eq!(ranges_overlaps(&[0..4, 5..8], &(4..5)), true);
+        assert_eq!(ranges_overlaps(&[0..4, 5..8], &(0..9)), true);
+    }
+
+    #[test]
+    fn test_ranges_contains() {
+        assert_eq!(ranges_contains(&[0..4], &0), true);
+        assert_eq!(ranges_contains(&[0..4], &4), false);
+        assert_eq!(ranges_contains(&[0..4, 5..8], &4), false);
+        assert_eq!(ranges_contains(&[0..4, 5..8], &6), true);
+    }
 }


### PR DESCRIPTION
When the original payload extents are all in order and have no gaps, we can efficiently copy unmodified chunks of the system image from the original payload into the new payload. Only the chunks containing the modified regions (`otacerts.zip`, hash tree, FEC data, and AVB metadata) need to be recompressed. This massively reduces the CPU usage since usually only <20 MiB need to be recompressed.

If the conditions for the optimized path aren't satisfied (eg. extents aren't in order or `--replace` is used), then it falls back to splitting and compressing the entire system image.

This fixes the performance issues introduced in #240. This is probably the best that we can do given that we now always patch the system image.

Issue: #225