### PR TITLE
Switch from xz2 to liblzma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "flate2",
  "gf256",
  "hex",
+ "liblzma",
  "lz4_flex",
  "memchr",
  "num-bigint-dig",
@@ -151,7 +152,6 @@ dependencies = [
  "toml_edit",
  "topological-sort",
  "x509-cert",
- "xz2",
  "zip",
 ]
 
@@ -301,6 +301,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -792,6 +793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +815,26 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "liblzma"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0a90100aae90523703bd088bc3b57352bbded8b3fc274de0d5759438ced354"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340bd13b7f626bad0fbcae3dacbda397e9de1114910a6743a55ae731c80c97c6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -863,16 +893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "git+https://github.com/chenxiaolong/xz2-rs?rev=fe2050b9c3395db15d8610f1dabb505440c1a556#fe2050b9c3395db15d8610f1dabb505440c1a556"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1907,14 +1927,6 @@ dependencies = [
  "clap",
  "regex",
  "toml_edit",
-]
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "git+https://github.com/chenxiaolong/xz2-rs?rev=fe2050b9c3395db15d8610f1dabb505440c1a556#fe2050b9c3395db15d8610f1dabb505440c1a556"
-dependencies = [
- "lzma-sys",
 ]
 
 [[package]]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -24,6 +24,7 @@ ctrlc = "3.4.0"
 flate2 = "1.0.27"
 gf256 = { version = "0.3.0", features = ["rs"] }
 hex = { version = "0.4.3", features = ["serde"] }
+liblzma = "0.2.1"
 lz4_flex = "0.11.1"
 memchr = "2.6.0"
 num-bigint-dig = "0.8.4"
@@ -59,14 +60,6 @@ x509-cert = { version = "0.2.4", features = ["builder"] }
 git = "https://github.com/jongiddy/bzip2-rs"
 rev = "2aefcb4d3634de1df226c73d93f758d65228bb8c"
 
-# The upstream xz2 crate uses an old version of liblzma when compiling with the
-# `static` feature and doesn't enable all of the encoders and decoders. This
-# causes certain payload data to fail to decompress.
-# https://github.com/chenxiaolong/avbroot/issues/138
-[dependencies.xz2]
-git = "https://github.com/chenxiaolong/xz2-rs"
-rev = "fe2050b9c3395db15d8610f1dabb505440c1a556"
-
 # https://github.com/zip-rs/zip/pull/383
 [dependencies.zip]
 git = "https://github.com/chenxiaolong/zip"
@@ -85,4 +78,4 @@ protox = "0.5.0"
 assert_matches = "1.5.0"
 
 [features]
-static = ["bzip2/static", "xz2/static"]
+static = ["bzip2/static", "liblzma/static"]

--- a/avbroot/src/format/compression.rs
+++ b/avbroot/src/format/compression.rs
@@ -7,14 +7,14 @@ use std::io::{self, Read, Seek, Write};
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
-use lz4_flex::frame::FrameDecoder;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-use xz2::{
+use liblzma::{
     read::XzDecoder,
     stream::{Check, Stream},
     write::XzEncoder,
 };
+use lz4_flex::frame::FrameDecoder;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 static GZIP_MAGIC: &[u8; 2] = b"\x1f\x8b";
 static LZ4_LEGACY_MAGIC: &[u8; 4] = b"\x02\x21\x4c\x18";
@@ -25,7 +25,7 @@ pub enum Error {
     #[error("Unknown compression format")]
     UnknownFormat,
     #[error("XZ stream error")]
-    XzStream(#[from] xz2::stream::Error),
+    XzStream(#[from] liblzma::stream::Error),
     #[error("I/O error")]
     Io(#[from] io::Error),
 }

--- a/avbroot/src/format/payload.rs
+++ b/avbroot/src/format/payload.rs
@@ -14,6 +14,11 @@ use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use byteorder::{BigEndian, ReadBytesExt};
 use bzip2::write::BzDecoder;
+use liblzma::{
+    stream::{Check, Stream},
+    write::XzDecoder,
+    write::XzEncoder,
+};
 use num_traits::ToPrimitive;
 use prost::Message;
 use rayon::{
@@ -25,11 +30,6 @@ use rsa::{traits::PublicKeyParts, Pkcs1v15Sign, RsaPrivateKey};
 use sha2::Sha256;
 use thiserror::Error;
 use x509_cert::Certificate;
-use xz2::{
-    stream::{Check, Stream},
-    write::XzDecoder,
-    write::XzEncoder,
-};
 
 use crate::{
     crypto,
@@ -99,7 +99,7 @@ pub enum Error {
     #[error("Failed to decode protobuf message")]
     ProtobufDecode(#[from] prost::DecodeError),
     #[error("XZ stream error")]
-    XzStream(#[from] xz2::stream::Error),
+    XzStream(#[from] liblzma::stream::Error),
     #[error("RSA error")]
     Rsa(#[from] rsa::Error),
     #[error("I/O error")]

--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -16,16 +16,16 @@ use std::{
 };
 
 use bstr::ByteSlice;
+use liblzma::{
+    stream::{Check, Stream},
+    write::XzEncoder,
+};
 use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
 use regex::bytes::Regex;
 use ring::digest::Context;
 use rsa::RsaPrivateKey;
 use thiserror::Error;
 use x509_cert::Certificate;
-use xz2::{
-    stream::{Check, Stream},
-    write::XzEncoder,
-};
 use zip::{result::ZipError, ZipArchive};
 
 use crate::{
@@ -67,7 +67,7 @@ pub enum Error {
     #[error("OTA certificate error")]
     OtaCert(#[from] otacert::Error),
     #[error("XZ stream error")]
-    XzStream(#[from] xz2::stream::Error),
+    XzStream(#[from] liblzma::stream::Error),
     #[error("Zip error")]
     Zip(#[from] ZipError),
     #[error("I/O error")]

--- a/deny.toml
+++ b/deny.toml
@@ -65,13 +65,14 @@ include-workspace = true
 bypass = [
     # Copies of unmodified crashwrangler objects for old macOS versions.
     { name = "honggfuzz", allow-globs = ["honggfuzz/third_party/mac/CrashReport_*.o"] },
+    # Test files for liblzma's test suite
+    { name = "liblzma-sys", allow-globs = ["xz/tests/compress_prepared_bcj_*"] },
 ]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
-    "https://github.com/chenxiaolong/xz2-rs",
     "https://github.com/chenxiaolong/zip",
     "https://github.com/jongiddy/bzip2-rs",
 ]


### PR DESCRIPTION
liblzma is a maintained fork of xz2. We can now get rid of our own fork of xz2.