### PR TITLE
Add tracing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,8 @@ dependencies = [
  "thiserror",
  "toml_edit",
  "topological-sort",
+ "tracing",
+ "tracing-subscriber",
  "x509-cert",
  "zip",
 ]
@@ -361,7 +363,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -519,7 +521,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -549,6 +551,8 @@ dependencies = [
  "tempfile",
  "toml_edit",
  "topological-sort",
+ "tracing",
+ "tracing-subscriber",
  "x509-cert",
  "zip",
 ]
@@ -874,7 +878,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -936,7 +940,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -963,6 +967,16 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1019,6 +1033,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pbkdf2"
@@ -1079,7 +1099,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1090,6 +1110,12 @@ checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkcs1"
@@ -1148,14 +1174,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1187,7 +1213,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.43",
+ "syn 2.0.48",
  "tempfile",
  "which",
 ]
@@ -1202,7 +1228,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1256,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1466,22 +1492,22 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1513,6 +1539,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1590,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1629,7 +1664,17 @@ checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1650,7 +1695,7 @@ checksum = "d8e00e3e7a54e0f1c8834ce72ed49c8487fbd3f801d8cfe1a0ad0640382f8e15"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1680,6 +1725,63 @@ name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "twox-hash"
@@ -1731,6 +1833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1861,28 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1946,7 +2076,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -49,6 +49,8 @@ tempfile = "3.8.0"
 thiserror = "1.0.47"
 toml_edit = { version = "0.21.0", features = ["serde"] }
 topological-sort = "0.2.2"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 x509-cert = { version = "0.2.4", features = ["builder"] }
 
 # There's an upstream bug that causes an infinite loop in the write::BzDecoder

--- a/avbroot/src/cli/args.rs
+++ b/avbroot/src/cli/args.rs
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-use std::sync::atomic::AtomicBool;
+use std::{
+    fmt,
+    io::{self, IsTerminal},
+    sync::atomic::{AtomicBool, Ordering},
+    time::Instant,
+};
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+use tracing::{debug, Level};
+use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
 
 use crate::cli::{avb, boot, completion, cpio, fec, hashtree, key, ota};
 
@@ -29,15 +36,123 @@ pub enum Command {
     MagiskInfo(boot::MagiskInfoCli),
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    fn as_level(self) -> Level {
+        match self {
+            Self::Trace => Level::TRACE,
+            Self::Debug => Level::DEBUG,
+            Self::Info => Level::INFO,
+            Self::Warn => Level::WARN,
+            Self::Error => Level::ERROR,
+        }
+    }
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_possible_value().ok_or(fmt::Error)?.get_name())
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum LogFormat {
+    Short,
+    Medium,
+    Long,
+}
+
+impl Default for LogFormat {
+    fn default() -> Self {
+        Self::Short
+    }
+}
+
+impl fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_possible_value().ok_or(fmt::Error)?.get_name())
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
+
+    /// Lowest log message severity to output.
+    #[arg(long, global = true, value_name = "LEVEL", default_value_t)]
+    pub log_level: LogLevel,
+
+    /// Output format for log messages.
+    #[arg(long, global = true, value_name = "FORMAT", default_value_t)]
+    pub log_format: LogFormat,
 }
 
-pub fn main(cancel_signal: &AtomicBool) -> Result<()> {
+#[derive(Debug, Clone, Copy)]
+pub struct ShortUptime {
+    epoch: Instant,
+}
+
+impl Default for ShortUptime {
+    fn default() -> Self {
+        Self {
+            epoch: Instant::now(),
+        }
+    }
+}
+
+impl FormatTime for ShortUptime {
+    fn format_time(&self, w: &mut Writer<'_>) -> fmt::Result {
+        let e = self.epoch.elapsed();
+        write!(w, "{:3}.{:03}s", e.as_secs(), e.subsec_millis())
+    }
+}
+
+pub fn init_logging(log_level: LogLevel, log_format: LogFormat) {
+    let builder = tracing_subscriber::fmt()
+        .with_writer(io::stderr)
+        .with_ansi(io::stderr().is_terminal())
+        .with_max_level(log_level.as_level());
+
+    match log_format {
+        LogFormat::Short => {
+            let format = tracing_subscriber::fmt::format()
+                .with_timer(ShortUptime::default())
+                .with_target(false);
+
+            builder.event_format(format).init();
+        }
+        LogFormat::Medium => {
+            builder.with_timer(ShortUptime::default()).init();
+        }
+        LogFormat::Long => {
+            builder.pretty().init();
+        }
+    }
+}
+
+pub fn main(logging_initialized: &AtomicBool, cancel_signal: &AtomicBool) -> Result<()> {
     let cli = Cli::parse();
+
+    init_logging(cli.log_level, cli.log_format);
+    logging_initialized.store(true, Ordering::SeqCst);
+
+    debug!(?cli);
 
     match cli.command {
         Command::Avb(c) => avb::avb_main(&c, cancel_signal),

--- a/avbroot/src/cli/mod.rs
+++ b/avbroot/src/cli/mod.rs
@@ -12,18 +12,3 @@ pub mod fec;
 pub mod hashtree;
 pub mod key;
 pub mod ota;
-
-macro_rules! status {
-    ($($arg:tt)*) => {
-        eprintln!("\x1b[1m[*] {}\x1b[0m", format!($($arg)*))
-    }
-}
-
-macro_rules! warning {
-    ($($arg:tt)*) => {
-        eprintln!("\x1b[1;31m[WARNING] {}\x1b[0m", format!($($arg)*))
-    }
-}
-
-pub(crate) use status;
-pub(crate) use warning;

--- a/avbroot/src/patch/otacert.rs
+++ b/avbroot/src/patch/otacert.rs
@@ -7,6 +7,7 @@ use std::{borrow::Cow, cmp::Ordering, io::Cursor};
 
 use bitflags::bitflags;
 use thiserror::Error;
+use tracing::trace;
 use x509_cert::{der::asn1::BitString, Certificate};
 use zip::{result::ZipError, write::FileOptions, CompressionMethod, ZipWriter};
 
@@ -134,8 +135,12 @@ pub fn create_zip_with_size(cert: &Certificate, size: usize) -> Result<Vec<u8>> 
     ] {
         flags |= additional_flag;
 
+        trace!("Attempting to create {size} byte otacerts.zip: {flags:?}");
+
         let mut data = create_zip(cert, flags)?;
         if data.len() <= size {
+            trace!("Padding {} byte otacerts.zip to {size}", data.len());
+
             pad_zip(&mut data, size)?;
             return Ok(data);
         }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -20,6 +20,8 @@ serde = { version = "1.0.188", features = ["derive"] }
 tempfile = "3.8.0"
 toml_edit = { version = "0.21.0", features = ["serde"] }
 topological-sort = "0.2.2"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 x509-cert = "0.2.5"
 
 # https://github.com/zip-rs/zip/pull/383

--- a/e2e/src/cli.rs
+++ b/e2e/src/cli.rs
@@ -5,6 +5,7 @@
 
 use std::path::PathBuf;
 
+use avbroot::cli::args::{LogFormat, LogLevel};
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Debug, Args)]
@@ -66,4 +67,12 @@ pub enum Command {
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
+
+    /// Lowest log message severity to output.
+    #[arg(long, global = true, value_name = "LEVEL", default_value_t)]
+    pub log_level: LogLevel,
+
+    /// Output format for log messages.
+    #[arg(long, global = true, value_name = "FORMAT", default_value_t = LogFormat::Medium)]
+    pub log_format: LogFormat,
 }


### PR DESCRIPTION
Instead of println'ing everything, this commit switches the code base to using the tracing library. There are now proper log levels and multiple logging output formats. A bunch of new debug and trace-level messages have also been added to help with future troubleshooting.

<details>
<summary>EDIT: Ugly structured logging is no longer used</summary>

The output is a bit uglier than before due to liberal use of spans and structured logging. We can tweak the message formatting later if needed.

Screenshots:

* [`--log-format short` (Default)](https://github.com/chenxiaolong/avbroot/assets/646253/39326f3a-dcf2-4d97-88eb-70feff524c80)
* [`--log-format medium`](https://github.com/chenxiaolong/avbroot/assets/646253/82e33ddb-3da8-4701-9124-2c2ff072d2a7)
* [`--log-format long`](https://github.com/chenxiaolong/avbroot/assets/646253/6bbbd62a-fd0a-4036-863d-5ff8b4dce137)
* [`--log-format json`](https://github.com/chenxiaolong/avbroot/assets/646253/6c38e16b-7e14-4629-ac38-671a7294a4d2)
  * If, for whatever reason, someone needs to parse avbroot's output, then this is the way to do it. All fields use proper JSON types. No need to do ugly string parsing.
* [`--log-level debug` (with default format)](https://github.com/chenxiaolong/avbroot/assets/646253/68aacdb8-88ad-49e1-92f7-1c761c5606e6)
* [`--log-level trace` (with default format)](https://github.com/chenxiaolong/avbroot/assets/646253/22c28920-8642-4c9b-afee-e1e0ec4d9242)
* [e2e tests](https://github.com/chenxiaolong/avbroot/assets/646253/c384efac-b984-42ae-9161-41196ad675a9)
</details>