### PR TITLE
Switch to my fork of the bzip2-rs library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 [[package]]
 name = "bzip2"
 version = "0.4.4"
-source = "git+https://github.com/jongiddy/bzip2-rs?rev=2aefcb4d3634de1df226c73d93f758d65228bb8c#2aefcb4d3634de1df226c73d93f758d65228bb8c"
+source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=6e0f9836ec87b19261461b6cc1772e14aff8e851#6e0f9836ec87b19261461b6cc1772e14aff8e851"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
-source = "git+https://github.com/jongiddy/bzip2-rs?rev=2aefcb4d3634de1df226c73d93f758d65228bb8c#2aefcb4d3634de1df226c73d93f758d65228bb8c"
+source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=6e0f9836ec87b19261461b6cc1772e14aff8e851#6e0f9836ec87b19261461b6cc1772e14aff8e851"
 dependencies = [
  "cc",
  "libc",

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -53,14 +53,12 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 x509-cert = { version = "0.2.4", features = ["builder"] }
 
-# There's an upstream bug that causes an infinite loop in the write::BzDecoder
-# destructor if the decoder is fed invalid data. While this never happens during
-# normal operation, it is possible to run into this by running `ota extract`
-# against a `--stripped` OTA file.
-# https://github.com/alexcrichton/bzip2-rs/pull/99
+# There are multiple upstream bugs that cause infinite loops in the Drop
+# implementation of write::BzDecoder. Unfortunately, the project is no longer
+# maintained, so we have to maintain our own fork with the necessary fixes.
 [dependencies.bzip2]
-git = "https://github.com/jongiddy/bzip2-rs"
-rev = "2aefcb4d3634de1df226c73d93f758d65228bb8c"
+git = "https://github.com/chenxiaolong/bzip2-rs"
+rev = "6e0f9836ec87b19261461b6cc1772e14aff8e851"
 
 # https://github.com/zip-rs/zip/pull/383
 [dependencies.zip]

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,6 @@ bypass = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
+    "https://github.com/chenxiaolong/bzip2-rs",
     "https://github.com/chenxiaolong/zip",
-    "https://github.com/jongiddy/bzip2-rs",
 ]


### PR DESCRIPTION
This includes a fix for yet another infinite-loop-on-drop bug in the bzip2::write::BzDecoder implementation. This could be easily triggered when interrupting an avbroot command while it is extracting a bzip2 compressed payload.bin chunk.

Fixes: #285