### PR TITLE
avb: Bump hashtree and FEC size limits to accommodate 8 GiB images

### DIFF
--- a/avbroot/src/format/avb.rs
+++ b/avbroot/src/format/avb.rs
@@ -50,13 +50,30 @@ pub const FOOTER_MAGIC: [u8; 4] = *b"AVBf";
 /// for early fail. No individual field can actually be this size.
 pub const HEADER_MAX_SIZE: u64 = 64 * 1024;
 
-/// Maximum hash tree size. The current limit equals the hash tree size for a
-/// 4GiB image using SHA512 digests and a block size of 4096.
-pub const HASH_TREE_MAX_SIZE: u64 = 68_177_920;
+/// Maximum hash tree size. The current limit equals the hash tree size for an
+/// 8GiB image using SHA256 digests and a block size of 4096. This is equal to:
+///
+/// ```rust
+/// use avbroot::format::hashtree::HashTree;
+/// let size = HashTree::new(4096, &ring::digest::SHA256, b"")
+///     .compute_level_offsets(8 * 1024 * 1024 * 1024)
+///     .unwrap()
+///    .first()
+///    .map(|r| r.end)
+///    .unwrap_or(0);
+/// ```
+pub const HASH_TREE_MAX_SIZE: u64 = 67_637_248;
 
-/// Maximum FEC data size. The current limit equals the FEC data size for a 4GiB
-/// image using 2 parity bytes per codeword.
-pub const FEC_DATA_MAX_SIZE: u64 = 33_959_936;
+/// Maximum FEC data size. The current limit equals the FEC data size for an
+/// 8GiB image using 2 parity bytes per codeword. This is equal to:
+///
+/// ```rust
+/// use avbroot::format::fec::Fec;
+/// let size = Fec::new(8 * 1024 * 1024 * 1024, 4096, 2)
+///     .unwrap()
+///     .fec_size();
+/// ```
+pub const FEC_DATA_MAX_SIZE: u64 = 67_911_680;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/avbroot/src/format/fec.rs
+++ b/avbroot/src/format/fec.rs
@@ -166,8 +166,8 @@ impl Fec {
             return Err(Error::UnsupportedParity(parity));
         }
 
-        let blocks = util::div_ceil(file_size, u64::from(block_size));
-        let rounds = util::div_ceil(blocks, u64::from(rs_k));
+        let blocks = file_size.div_ceil(u64::from(block_size));
+        let rounds = blocks.div_ceil(u64::from(rs_k));
 
         // Check upfront so we don't need to do checked multiplication later.
         rounds
@@ -225,7 +225,7 @@ impl Fec {
             let end_block = if range.end % block_size == 0 {
                 range.end / block_size
             } else {
-                util::div_ceil(range.end, block_size)
+                range.end.div_ceil(block_size)
             };
 
             for block in start_block..end_block {

--- a/avbroot/src/format/fec.rs
+++ b/avbroot/src/format/fec.rs
@@ -196,7 +196,7 @@ impl Fec {
 
     /// Get the size of the FEC data needed to cover the entire file.
     #[inline]
-    fn fec_size(&self) -> usize {
+    pub fn fec_size(&self) -> usize {
         usize::from(self.parity()) * self.rounds as usize * self.block_size as usize
     }
 

--- a/avbroot/src/format/hashtree.rs
+++ b/avbroot/src/format/hashtree.rs
@@ -72,7 +72,7 @@ impl HashTree {
     /// tree data. The items are returned with the bottom level's offsets first
     /// in the list. Note that the bottom level is stored at the end of the hash
     /// tree data.
-    fn compute_level_offsets(&self, image_size: u64) -> Result<Vec<Range<usize>>> {
+    pub fn compute_level_offsets(&self, image_size: u64) -> Result<Vec<Range<usize>>> {
         let algorithm = self.salted_context.algorithm();
         let digest_size = algorithm.output_len().next_power_of_two();
         let mut ranges = vec![];

--- a/avbroot/src/format/hashtree.rs
+++ b/avbroot/src/format/hashtree.rs
@@ -79,7 +79,7 @@ impl HashTree {
         let mut level_size = image_size;
 
         while level_size > u64::from(self.block_size) {
-            let blocks = util::div_ceil(level_size, u64::from(self.block_size));
+            let blocks = level_size.div_ceil(u64::from(self.block_size));
             level_size = blocks
                 .checked_mul(digest_size as u64)
                 .and_then(|s| padding::round(s, u64::from(self.block_size)))
@@ -124,7 +124,7 @@ impl HashTree {
             let end_block = if range.end % block_size == 0 {
                 range.end / block_size
             } else {
-                util::div_ceil(range.end, block_size)
+                range.end.div_ceil(block_size)
             };
 
             result.push(start_block..end_block);

--- a/avbroot/src/format/payload.rs
+++ b/avbroot/src/format/payload.rs
@@ -918,7 +918,7 @@ pub fn compress_image(
         });
     }
 
-    let chunks_total = util::div_ceil(file_size, CHUNK_SIZE);
+    let chunks_total = file_size.div_ceil(CHUNK_SIZE);
     let mut bytes_compressed = 0;
     let mut context_uncompressed = Context::new(&ring::digest::SHA256);
     let mut operations = vec![];
@@ -1059,7 +1059,7 @@ pub fn compress_modified_image(
         return Err(Error::ExtentsNotInOrder);
     }
 
-    let groups_total = util::div_ceil(operations.len(), OPERATION_GROUP);
+    let groups_total = operations.len().div_ceil(OPERATION_GROUP);
     let mut bytes_compressed = 0;
     let mut context_uncompressed = Context::new(&ring::digest::SHA256);
     let mut modified_operations = vec![];

--- a/avbroot/src/patch/system.rs
+++ b/avbroot/src/patch/system.rs
@@ -129,7 +129,7 @@ pub fn patch_system_image(
         return Err(Error::NoHashTreeDescriptor);
     };
 
-    let num_chunks = util::div_ceil(footer.original_image_size, CHUNK_SIZE);
+    let num_chunks = footer.original_image_size.div_ceil(CHUNK_SIZE);
     trace!("Parallel heuristics search for otacerts.zip with {num_chunks} chunks");
 
     let modified_ranges = (0..num_chunks)

--- a/avbroot/src/util.rs
+++ b/avbroot/src/util.rs
@@ -49,16 +49,6 @@ pub fn parent_path(path: &Path) -> &Path {
     Path::new(".")
 }
 
-/// Since Rust's built-in .div_ceil() is still nightly-only.
-pub fn div_ceil<T: PrimInt>(dividend: T, divisor: T) -> T {
-    dividend / divisor
-        + if dividend % divisor != T::zero() {
-            T::one()
-        } else {
-            T::zero()
-        }
-}
-
 /// Sort and merge overlapping intervals.
 pub fn merge_overlapping<T>(sections: &[Range<T>]) -> Vec<Range<T>>
 where


### PR DESCRIPTION
Fixes: https://github.com/chenxiaolong/avbroot/issues/291