### PR TITLE
Add payload subcommand for dumping payload.bin header

### DIFF
--- a/README.extra.md
+++ b/README.extra.md
@@ -252,3 +252,13 @@ avbroot hash-tree verify -i <input data file> -H <input hash tree file>
 ```
 
 This will check if the input file has any corrupted blocks. Currently, the command cannot report which specific blocks are corrupted, only whether the file is valid.
+
+## `avbroot payload`
+
+### Showing payload header information
+
+```bash
+avbroot payload info -i <payload>
+```
+
+This subcommand shows all of the payload header fields (which will likely be extremely long).

--- a/avbroot/src/cli/args.rs
+++ b/avbroot/src/cli/args.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -15,7 +15,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use tracing::{debug, Level};
 use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
 
-use crate::cli::{avb, boot, completion, cpio, fec, hashtree, key, ota};
+use crate::cli::{avb, boot, completion, cpio, fec, hashtree, key, ota, payload};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
@@ -28,6 +28,7 @@ pub enum Command {
     HashTree(hashtree::HashTreeCli),
     Key(key::KeyCli),
     Ota(ota::OtaCli),
+    Payload(payload::PayloadCli),
     /// (Deprecated: Use `avbroot ota patch` instead.)
     Patch(ota::PatchCli),
     /// (Deprecated: Use `avbroot ota extract` instead.)
@@ -163,6 +164,7 @@ pub fn main(logging_initialized: &AtomicBool, cancel_signal: &AtomicBool) -> Res
         Command::HashTree(c) => hashtree::hash_tree_main(&c, cancel_signal),
         Command::Key(c) => key::key_main(&c),
         Command::Ota(c) => ota::ota_main(&c, cancel_signal),
+        Command::Payload(c) => payload::payload_main(&c),
         // Deprecated aliases.
         Command::Patch(c) => ota::patch_subcommand(&c, cancel_signal),
         Command::Extract(c) => ota::extract_subcommand(&c, cancel_signal),

--- a/avbroot/src/cli/mod.rs
+++ b/avbroot/src/cli/mod.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -12,3 +12,4 @@ pub mod fec;
 pub mod hashtree;
 pub mod key;
 pub mod ota;
+pub mod payload;

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+
+use crate::{format::payload::PayloadHeader, stream::FromReader};
+
+fn info_subcommand(cli: &InfoCli) -> Result<()> {
+    let mut reader = File::open(&cli.input)
+        .map(BufReader::new)
+        .with_context(|| format!("Failed to open payload: {:?}", cli.input))?;
+    let header = PayloadHeader::from_reader(&mut reader)
+        .with_context(|| format!("Failed to read payload: {:?}", cli.input))?;
+
+    println!("{header:#?}");
+
+    Ok(())
+}
+
+pub fn payload_main(cli: &PayloadCli) -> Result<()> {
+    match &cli.command {
+        PayloadCommand::Info(c) => info_subcommand(c),
+    }
+}
+
+/// Display payload information.
+#[derive(Debug, Parser)]
+struct InfoCli {
+    /// Path to input payload file.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    input: PathBuf,
+}
+
+#[derive(Debug, Subcommand)]
+enum PayloadCommand {
+    Info(InfoCli),
+}
+
+/// Inspect OTA payloads.
+#[derive(Debug, Parser)]
+pub struct PayloadCli {
+    #[command(subcommand)]
+    command: PayloadCommand,
+}


### PR DESCRIPTION
I'm tired of adding `println!("{header:#?}")` to troubleshoot things. Let's add an actual subcommand for dumping the headers of `payload.bin` files.