### PR TITLE
Add support for Magisk 27006

### DIFF
--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -161,6 +161,7 @@ impl MagiskRootPatcher {
     const VER_XZ_BACKUP: Range<u32> =
         26403..Self::VERS_SUPPORTED[Self::VERS_SUPPORTED.len() - 1].end;
 
+    const ZIP_INIT_LD: &'static str = "lib/arm64-v8a/libinit-ld.so";
     const ZIP_LIBMAGISK: &'static str = "lib/arm64-v8a/libmagisk.so";
     const ZIP_LIBMAGISK32: &'static str = "lib/armeabi-v7a/libmagisk32.so";
     const ZIP_LIBMAGISK64: &'static str = "lib/arm64-v8a/libmagisk64.so";
@@ -460,6 +461,13 @@ impl BootImagePatch for MagiskRootPatcher {
         if zip.file_names().any(|n| n == Self::ZIP_STUB) {
             debug!("Magisk stub found");
             xz_files.insert(Self::ZIP_STUB, b"overlay.d/sbin/stub.xz");
+        }
+
+        // Add init-ld, which only exists after Magisk commit
+        // 33aebb59763b6ec27209563035303700e998633d
+        if zip.file_names().any(|n| n == Self::ZIP_INIT_LD) {
+            debug!("Magisk init-ld found");
+            xz_files.insert(Self::ZIP_INIT_LD, b"overlay.d/sbin/init-ld.xz");
         }
 
         for (source, target) in xz_files {

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -47,7 +47,7 @@ data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v4_gki.hashes]
 original = "6b140c378d21eae2fa4fc581bce13a689b21bd32f5fba865698d1fd322f2f8c6"
-patched = "f00e9745f90754be28ce8355501d876759cd8336451e4c3633908fbb4217b422"
+patched = "a68b3a44c0cf015a225f92837c05fd0dec6e159584c5880eff30d12daa7123ff"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -81,7 +81,7 @@ data.ramdisks = [["init", "otacerts", "first_stage", "dsu_key_dir"], ["dlkm"]]
 
 [profile.pixel_v4_non_gki.hashes]
 original = "31963e6f81986c6686111f50e36b89e4d85ee5c02bc8e5ecd560528bc98d6fe7"
-patched = "43959409034dbb9aa0a605d7c5c0e7885012bbcd63510ec87d8e97015b37a746"
+patched = "a13173a006ad94b25db682bb14fde2e36891417727d6541bdf5f9bca57d26751"
 
 # Google Pixel 4a 5G
 # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -116,7 +116,7 @@ data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v3.hashes]
 original = "e684aacb54464098c1b8e3f499efe35dff10ea792e89d71a83404620d0108b3e"
-patched = "08e03ec327bf5bd841b91ad8d53028c3439a1722b423aaaac6cc0ceee4ef66b1"
+patched = "49e810ae76154bccf2dc7d810b9eec19d23a5b8fa32381469660488d0a25121b"
 
 # Google Pixel 4a
 # What's unique: boot (boot v2)
@@ -145,4 +145,4 @@ data.deps = ["system"]
 
 [profile.pixel_v2.hashes]
 original = "ee9568797d9195985f14753b89949d8ebb08c8863a32eceeeec6e8d94661b1cf"
-patched = "5e265094d4164cedde8f483911c58860f6008b314dc8e5ed3b44deb53fbb2f96"
+patched = "e413f1f87ee5ba53d402edad03b0df8af451b5b0323202a9d32b8327d433d340"

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -830,12 +830,16 @@ fn create_fake_magisk(output: &Path) -> Result<()> {
 
     for path in [
         "assets/stub.apk",
+        "lib/arm64-v8a/libinit-ld.so",
         "lib/arm64-v8a/libmagisk64.so",
         "lib/arm64-v8a/libmagiskinit.so",
+        "lib/armeabi-v7a/libinit-ld.so",
         "lib/armeabi-v7a/libmagisk32.so",
         "lib/armeabi-v7a/libmagiskinit.so",
+        "lib/x86/libinit-ld.so",
         "lib/x86/libmagisk32.so",
         "lib/x86/libmagiskinit.so",
+        "lib/x86_64/libinit-ld.so",
         "lib/x86_64/libmagisk64.so",
         "lib/x86_64/libmagiskinit.so",
     ] {


### PR DESCRIPTION
Version 27006 now requires `init-ld` to be included in the ramdisk.