### PR TITLE
Add subcommands for packing and unpacking payload binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "clap_complete",
  "cms",
  "const-oid",
+ "constcat",
  "ctrlc",
  "flate2",
  "gf256",
@@ -397,6 +398,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constcat"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2e5af989b1955b092db01462980c0a286217f86817e12b2c09aea46bd03651"
 
 [[package]]
 name = "cpufeatures"

--- a/README.extra.md
+++ b/README.extra.md
@@ -255,6 +255,36 @@ This will check if the input file has any corrupted blocks. Currently, the comma
 
 ## `avbroot payload`
 
+### Unpacking a payload binary
+
+```bash
+avbroot payload unpack -i <input payload>
+```
+
+This subcommand unpacks the payload header information to `payload.toml` and the partition images to the `payload_images` directory.
+
+Only full payload binaries can be unpacked. Delta payload binaries from incremental OTAs are not supported.
+
+### Packing a payload binary
+
+```bash
+avbroot payload pack -o <output payload> --key <OTA private key>
+```
+
+This subcommand packs a new payload binary from the `payload.toml` file and `payload_images` directory. Any `.img` files in the `payload_images` directory that don't have a corresponding entry in `payload.toml` are silently ignored.
+
+Packing a payload binary requires compressing all of the partition images, which is very CPU intensive. If re-signing an existing payload binary without making any other modifications is all that's needed, use the `repack` subcommand instead.
+
+### Repacking a payload binary
+
+```bash
+avbroot payload repack -i <input payload> -o <output payload> --key <OTA private key>
+```
+
+This subcommand is logically equivalent to `avbroot payload unpack` followed by `avbroot payload pack`, except significantly more efficient. Instead of decompressing and recompressing all partition images, the raw data is directly copied from the input payload binary.
+
+This is useful for re-signing a payload binary without making any other changes.
+
 ### Showing payload header information
 
 ```bash

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -71,6 +71,7 @@ features = ["deflate"]
 rustix = { version = "0.38.9", default-features = false, features = ["process"] }
 
 [build-dependencies]
+constcat = "0.5.0"
 prost-build = "0.13.1"
 protox = "0.7.0"
 

--- a/avbroot/build.rs
+++ b/avbroot/build.rs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -30,8 +30,62 @@ fn main() {
 
     let file_descriptors = protox::compile(&protos, [&in_dir]).unwrap();
 
+    const CUE_AI: &str = ".chromeos_update_engine.ApexInfo";
+    const CUE_DAM: &str = ".chromeos_update_engine.DeltaArchiveManifest";
+    const CUE_DPG: &str = ".chromeos_update_engine.DynamicPartitionGroup";
+    const CUE_DPM: &str = ".chromeos_update_engine.DynamicPartitionMetadata";
+    const CUE_PU: &str = ".chromeos_update_engine.PartitionUpdate";
+    const CUE_VABCFS: &str = ".chromeos_update_engine.VABCFeatureSet";
+
+    const DERIVE_SERDE: &str = "#[derive(serde::Deserialize, serde::Serialize)]";
+    const SERDE_DEFAULT: &str = "#[serde(default)]";
+    const SERDE_SKIP: &str = "#[serde(skip)]";
+    const SERDE_SKIP_IF_VEC_EMPTY: &str = "#[serde(skip_serializing_if = \"Vec::is_empty\")]";
+
+    use constcat::concat as c;
+
     prost_build::Config::new()
         .btree_map(["."])
+        // Allow deserializing and serializing the types we care about.
+        .type_attribute(CUE_AI, DERIVE_SERDE)
+        .type_attribute(CUE_DAM, DERIVE_SERDE)
+        .type_attribute(CUE_DPG, DERIVE_SERDE)
+        .type_attribute(CUE_DPM, DERIVE_SERDE)
+        .type_attribute(CUE_PU, DERIVE_SERDE)
+        .type_attribute(CUE_VABCFS, DERIVE_SERDE)
+        // Allow default-initializing all fields.
+        .type_attribute(CUE_AI, SERDE_DEFAULT)
+        .type_attribute(CUE_DAM, SERDE_DEFAULT)
+        .type_attribute(CUE_DPG, SERDE_DEFAULT)
+        .type_attribute(CUE_DPM, SERDE_DEFAULT)
+        .type_attribute(CUE_PU, SERDE_DEFAULT)
+        .type_attribute(CUE_VABCFS, SERDE_DEFAULT)
+        // Don't serialize fields that define the structure of the payload
+        // binary and that we recompute during packing.
+        .field_attribute(c!(CUE_DAM, ".signatures_offset"), SERDE_SKIP)
+        .field_attribute(c!(CUE_DAM, ".signatures_size"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".operations"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".estimate_cow_size"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".old_partition_info"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".new_partition_info"), SERDE_SKIP)
+        // Don't serialize AVB 1.0 fields.
+        .field_attribute(c!(CUE_PU, ".hash_tree_data_extent"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".hash_tree_extent"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".hash_tree_algorithm"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".hash_tree_salt"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".fec_data_extent"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".fec_extent"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".fec_roots"), SERDE_SKIP)
+        // Don't serialize fields for incremental OTAs.
+        .field_attribute(c!(CUE_PU, ".merge_operations"), SERDE_SKIP)
+        // Don't serialize fields for vendor-signed images, which update_engine
+        // doesn't support anyway.
+        .field_attribute(c!(CUE_PU, ".new_partition_signature"), SERDE_SKIP)
+        // Don't serialize empty lists.
+        .field_attribute(c!(CUE_DAM, ".apex_info"), SERDE_SKIP_IF_VEC_EMPTY)
+        .field_attribute(c!(CUE_DAM, ".partitions"), SERDE_SKIP_IF_VEC_EMPTY)
+        .field_attribute(c!(CUE_DPG, ".partition_names"), SERDE_SKIP_IF_VEC_EMPTY)
+        .field_attribute(c!(CUE_DPM, ".groups"), SERDE_SKIP_IF_VEC_EMPTY)
         .compile_fds(file_descriptors)
         .unwrap();
 }

--- a/avbroot/src/cli/args.rs
+++ b/avbroot/src/cli/args.rs
@@ -164,7 +164,7 @@ pub fn main(logging_initialized: &AtomicBool, cancel_signal: &AtomicBool) -> Res
         Command::HashTree(c) => hashtree::hash_tree_main(&c, cancel_signal),
         Command::Key(c) => key::key_main(&c),
         Command::Ota(c) => ota::ota_main(&c, cancel_signal),
-        Command::Payload(c) => payload::payload_main(&c),
+        Command::Payload(c) => payload::payload_main(&c, cancel_signal),
         // Deprecated aliases.
         Command::Patch(c) => ota::patch_subcommand(&c, cancel_signal),
         Command::Extract(c) => ota::extract_subcommand(&c, cancel_signal),

--- a/avbroot/src/cli/cpio.rs
+++ b/avbroot/src/cli/cpio.rs
@@ -303,7 +303,7 @@ struct UnpackCli {
     #[arg(short, long, value_name = "FILE", value_parser)]
     input: PathBuf,
 
-    /// Path to output cpio info TOML.
+    /// Path to output info TOML.
     #[arg(long, value_name = "FILE", value_parser, default_value = "cpio.toml")]
     output_info: PathBuf,
 

--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -623,7 +623,7 @@ fn update_vbmeta_headers(
 /// If `ranges` is [`None`], then the entire file is compressed. Otherwise, only
 /// the chunks containing the specified ranges are compressed. In the latter
 /// scenario, unmodified chunks must be copied from the original payload.
-fn compress_image(
+pub fn compress_image(
     name: &str,
     file: &mut PSeekFile,
     header: &mut PayloadHeader,
@@ -900,7 +900,7 @@ fn patch_ota_payload(
         .with_context(|| format!("Failed to copy from original payload: {name}"))?;
     }
 
-    let (_, properties, metadata_size) = payload_writer
+    let (_, _, properties, metadata_size) = payload_writer
         .finish()
         .context("Failed to finalize payload")?;
 
@@ -1091,7 +1091,7 @@ fn patch_ota_zip(
     Ok((metadata, payload_metadata_size.unwrap()))
 }
 
-fn extract_ota_zip(
+pub fn extract_payload(
     raw_reader: &PSeekFile,
     directory: &Dir,
     payload_offset: u64,
@@ -1442,7 +1442,7 @@ pub fn extract_subcommand(cli: &ExtractCli, cancel_signal: &AtomicBool) -> Resul
     let directory = Dir::open_ambient_dir(&cli.directory, authority)
         .with_context(|| format!("Failed to open directory: {:?}", cli.directory))?;
 
-    extract_ota_zip(
+    extract_payload(
         &raw_reader,
         &directory,
         payload_offset,
@@ -1654,7 +1654,7 @@ pub fn verify_subcommand(cli: &VerifyCli, cancel_signal: &AtomicBool) -> Result<
         .cloned()
         .collect::<BTreeSet<_>>();
 
-    extract_ota_zip(
+    extract_payload(
         &raw_reader,
         &temp_dir,
         pf_payload.offset,
@@ -1864,7 +1864,7 @@ pub struct PatchCli {
         value_names = ["PARTITION", "FILE"],
         value_parser = value_parser!(OsString),
         num_args = 2,
-        help_heading = HEADING_PATH,
+        help_heading = HEADING_PATH
     )]
     pub replace: Vec<OsString>,
 

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -3,29 +3,446 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{
+    collections::HashMap,
+    ffi::{OsStr, OsString},
+    fs::{self, File},
+    io::{BufReader, BufWriter, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    sync::atomic::AtomicBool,
+};
 
-use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use anyhow::{anyhow, bail, Context, Result};
+use cap_std::{ambient_authority, fs::Dir};
+use clap::{Args, Parser, Subcommand};
+use tracing::info;
 
-use crate::{format::payload::PayloadHeader, stream::FromReader};
+use crate::{
+    cli::ota,
+    crypto::{self, PassphraseSource, RsaSigningKey},
+    format::payload::{PayloadHeader, PayloadWriter},
+    stream::{self, FromReader, PSeekFile},
+};
 
-fn info_subcommand(cli: &InfoCli) -> Result<()> {
-    let mut reader = File::open(&cli.input)
+fn open_reader(path: &Path) -> Result<(BufReader<File>, PayloadHeader)> {
+    let mut reader = File::open(path)
         .map(BufReader::new)
-        .with_context(|| format!("Failed to open payload: {:?}", cli.input))?;
+        .with_context(|| format!("Failed to open payload for reading: {path:?}"))?;
     let header = PayloadHeader::from_reader(&mut reader)
-        .with_context(|| format!("Failed to read payload: {:?}", cli.input))?;
+        .with_context(|| format!("Failed to read payload header: {path:?}"))?;
+    if !header.is_full_ota() {
+        bail!("Payload is a delta OTA, not a full OTA");
+    }
 
-    println!("{header:#?}");
+    Ok((reader, header))
+}
+
+fn open_writer(
+    path: &Path,
+    header: PayloadHeader,
+    key: RsaSigningKey,
+) -> Result<PayloadWriter<BufWriter<File>>> {
+    let writer = File::create(path)
+        .map(BufWriter::new)
+        .with_context(|| format!("Failed to open payload for writing: {path:?}"))?;
+    let payload_writer = PayloadWriter::new(writer, header, key)
+        .with_context(|| format!("Failed to write payload header: {path:?}"))?;
+
+    Ok(payload_writer)
+}
+
+fn read_info(path: &Path) -> Result<PayloadHeader> {
+    let data = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read payload info TOML: {path:?}"))?;
+    let info = toml_edit::de::from_str(&data)
+        .with_context(|| format!("Failed to parse payload info TOML: {path:?}"))?;
+
+    Ok(info)
+}
+
+fn write_info(path: &Path, manifest: &PayloadHeader) -> Result<()> {
+    let data = toml_edit::ser::to_string_pretty(manifest)
+        .with_context(|| format!("Failed to serialize payload info TOML: {path:?}"))?;
+    fs::write(path, data)
+        .with_context(|| format!("Failed to write payload info TOML: {path:?}"))?;
 
     Ok(())
 }
 
-pub fn payload_main(cli: &PayloadCli) -> Result<()> {
-    match &cli.command {
-        PayloadCommand::Info(c) => info_subcommand(c),
+fn display_header(cli: &PayloadCli, header: &PayloadHeader) {
+    if !cli.quiet {
+        println!("{header:#?}");
     }
+}
+
+fn load_key(group: &KeyGroup) -> Result<RsaSigningKey> {
+    let source = PassphraseSource::new(
+        &group.key,
+        group.pass_file.as_deref(),
+        group.pass_env_var.as_deref(),
+    );
+    let signing_key = if let Some(helper) = &group.signing_helper {
+        let public_key = crypto::read_pem_public_key_file(&group.key)
+            .with_context(|| format!("Failed to load key: {:?}", group.key))?;
+
+        RsaSigningKey::External {
+            program: helper.clone(),
+            public_key_file: group.key.clone(),
+            public_key,
+            passphrase_source: source,
+        }
+    } else {
+        let private_key = crypto::read_pem_key_file(&group.key, &source)
+            .with_context(|| format!("Failed to load key: {:?}", group.key))?;
+
+        RsaSigningKey::Internal(private_key)
+    };
+
+    Ok(signing_key)
+}
+
+fn unpack_subcommand(
+    payload_cli: &PayloadCli,
+    cli: &UnpackCli,
+    cancel_signal: &AtomicBool,
+) -> Result<()> {
+    let (mut reader, header) = open_reader(&cli.input)?;
+    let payload_size = reader
+        .seek(SeekFrom::End(0))
+        .with_context(|| format!("Failed to get file size: {:?}", cli.input))?;
+
+    display_header(payload_cli, &header);
+
+    write_info(&cli.output_info, &header)?;
+
+    let authority = ambient_authority();
+    Dir::create_ambient_dir_all(&cli.output_images, authority)
+        .with_context(|| format!("Failed to create directory: {:?}", cli.output_images))?;
+    let directory = Dir::open_ambient_dir(&cli.output_images, authority)
+        .with_context(|| format!("Failed to open directory: {:?}", cli.output_images))?;
+
+    ota::extract_payload(
+        &PSeekFile::new(reader.into_inner()),
+        &directory,
+        0,
+        payload_size,
+        &header,
+        &header
+            .manifest
+            .partitions
+            .iter()
+            .map(|p| &p.partition_name)
+            .cloned()
+            .collect(),
+        cancel_signal,
+    )?;
+
+    Ok(())
+}
+
+fn pack_subcommand(
+    payload_cli: &PayloadCli,
+    cli: &PackCli,
+    cancel_signal: &AtomicBool,
+) -> Result<()> {
+    let signing_key = load_key(&cli.key)?;
+
+    let mut header = read_info(&cli.input_info)?;
+
+    let authority = ambient_authority();
+    let directory = Dir::open_ambient_dir(&cli.input_images, authority)
+        .with_context(|| format!("Failed to open directory: {:?}", cli.input_images))?;
+
+    for p in &header.manifest.partitions {
+        let name = &p.partition_name;
+
+        if Path::new(name).file_name() != Some(OsStr::new(name)) {
+            bail!("Unsafe partition name: {name}");
+        }
+    }
+
+    // Pre-open all of the image files.
+    let input_files = header
+        .manifest
+        .partitions
+        .iter()
+        .map(|p| {
+            let path = format!("{}.img", p.partition_name);
+            let file = directory
+                .open(&path)
+                .map(|f| PSeekFile::new(f.into_std()))
+                .with_context(|| format!("Failed to open file: {path:?}"))?;
+
+            Ok((p.partition_name.clone(), file))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+
+    // Compress the images and compute the list of install operations for
+    // insertion into the payload header. The compressed data is stored in new
+    // temp files and the original input files are dropped.
+    let mut compressed_files = input_files
+        .into_iter()
+        .map(|(name, mut input_file)| {
+            ota::compress_image(&name, &mut input_file, &mut header, None, cancel_signal)
+                .with_context(|| format!("Failed to compress image: {name}"))?;
+
+            Ok((name, input_file))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+
+    info!("Generating new OTA payload");
+
+    // Now we can write the actual payload. With everything precomputed, this is
+    // mostly just a simple copy.
+    let mut payload_writer = open_writer(&cli.output, header.clone(), signing_key)?;
+
+    while payload_writer
+        .begin_next_operation()
+        .context("Failed to begin next payload blob entry")?
+    {
+        let name = payload_writer.partition().unwrap().partition_name.clone();
+        let operation = payload_writer.operation().unwrap();
+
+        let Some(data_length) = operation.data_length else {
+            // Otherwise, this is a ZERO/DISCARD operation.
+            continue;
+        };
+
+        let pi = payload_writer.partition_index().unwrap();
+        let oi = payload_writer.operation_index().unwrap();
+        let orig_partition = &header.manifest.partitions[pi];
+        let orig_operation = &orig_partition.operations[oi];
+        let data_offset = orig_operation
+            .data_offset
+            .ok_or_else(|| anyhow!("Missing data_offset in partition #{pi} operation #{oi}"))?;
+
+        // The compressed chunks are laid out sequentially and data_offset is
+        // set to the offset within that file.
+        let Some(input_file) = compressed_files.get_mut(&name) else {
+            unreachable!("Compressed data not found for image: {name}");
+        };
+
+        input_file
+            .seek(SeekFrom::Start(data_offset))
+            .with_context(|| format!("Failed to seek image: {name}"))?;
+
+        stream::copy_n(input_file, &mut payload_writer, data_length, cancel_signal)
+            .with_context(|| format!("Failed to copy from replacement image: {name}"))?;
+    }
+
+    let (_, header, properties, _) = payload_writer
+        .finish()
+        .context("Failed to finalize payload")?;
+
+    // Display the header information now that it has been finalized.
+    display_header(payload_cli, &header);
+
+    // Optionally, write payload_properties.txt.
+    if let Some(path) = &cli.output_properties {
+        fs::write(path, properties)
+            .with_context(|| format!("Failed to write payload properties: {path:?}"))?;
+    }
+
+    Ok(())
+}
+
+fn repack_subcommand(
+    payload_cli: &PayloadCli,
+    cli: &RepackCli,
+    cancel_signal: &AtomicBool,
+) -> Result<()> {
+    let signing_key = load_key(&cli.key)?;
+
+    let (mut reader, header) = open_reader(&cli.input)?;
+
+    info!("Generating new OTA payload");
+
+    let mut payload_writer = open_writer(&cli.output, header.clone(), signing_key)?;
+
+    while payload_writer
+        .begin_next_operation()
+        .context("Failed to begin next payload blob entry")?
+    {
+        let name = payload_writer.partition().unwrap().partition_name.clone();
+        let operation = payload_writer.operation().unwrap();
+
+        let Some(data_length) = operation.data_length else {
+            // Otherwise, this is a ZERO/DISCARD operation.
+            continue;
+        };
+
+        let pi = payload_writer.partition_index().unwrap();
+        let oi = payload_writer.operation_index().unwrap();
+        let orig_partition = &header.manifest.partitions[pi];
+        let orig_operation = &orig_partition.operations[oi];
+        let data_offset = orig_operation
+            .data_offset
+            .ok_or_else(|| anyhow!("Missing data_offset in partition #{pi} operation #{oi}"))?;
+
+        // Directly copy blobs from the original payload.
+        let data_offset = data_offset
+            .checked_add(header.blob_offset)
+            .ok_or_else(|| anyhow!("data_offset overflow in partition #{pi} operation #{oi}"))?;
+
+        reader
+            .seek(SeekFrom::Start(data_offset))
+            .with_context(|| format!("Failed to seek original payload to {data_offset}"))?;
+
+        stream::copy_n(&mut reader, &mut payload_writer, data_length, cancel_signal)
+            .with_context(|| format!("Failed to copy from original payload: {name}"))?;
+    }
+
+    let (_, header, properties, _) = payload_writer
+        .finish()
+        .context("Failed to finalize payload")?;
+
+    // Display the header information now that it has been finalized.
+    display_header(payload_cli, &header);
+
+    // Optionally, write payload_properties.txt.
+    if let Some(path) = &cli.output_properties {
+        fs::write(path, properties)
+            .with_context(|| format!("Failed to write payload properties: {path:?}"))?;
+    }
+
+    Ok(())
+}
+
+fn info_subcommand(payload_cli: &PayloadCli, cli: &InfoCli) -> Result<()> {
+    let (_, header) = open_reader(&cli.input)?;
+
+    display_header(payload_cli, &header);
+
+    Ok(())
+}
+
+pub fn payload_main(cli: &PayloadCli, cancel_signal: &AtomicBool) -> Result<()> {
+    match &cli.command {
+        PayloadCommand::Unpack(c) => unpack_subcommand(cli, c, cancel_signal),
+        PayloadCommand::Pack(c) => pack_subcommand(cli, c, cancel_signal),
+        PayloadCommand::Repack(c) => repack_subcommand(cli, c, cancel_signal),
+        PayloadCommand::Info(c) => info_subcommand(cli, c),
+    }
+}
+
+#[derive(Debug, Args)]
+struct KeyGroup {
+    /// Path to signing key.
+    ///
+    /// This should normally be a private key. However, if --signing-helper is
+    /// used, then it should be a public key instead.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    key: PathBuf,
+
+    /// Environment variable containing private key passphrase.
+    #[arg(long, value_name = "ENV_VAR", value_parser, group = "pass")]
+    pass_env_var: Option<OsString>,
+
+    /// File containing private key passphrase.
+    #[arg(long, value_name = "FILE", value_parser, group = "pass")]
+    pass_file: Option<PathBuf>,
+
+    /// External program for signing.
+    ///
+    /// If this option is specified, then --key must refer to a public key. The
+    /// program will be invoked as:
+    ///
+    /// <program> <algo> <public key> [file <pass file>|env <pass env>]
+    #[arg(long, value_name = "PROGRAM", value_parser)]
+    signing_helper: Option<PathBuf>,
+}
+
+/// Unpack a payload binary.
+///
+/// Each partition is extracted to `<partition name>.img` in the output images
+/// directory. The payload header metadata is written to the info TOML file.
+///
+/// If any partition names are unsafe to use in a path, the extraction process
+/// will fail and exit. Extracted files are never written outside of the tree
+/// directory, even if an external process tries to interfere.
+#[derive(Debug, Parser)]
+struct UnpackCli {
+    /// Path to input payload binary.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    input: PathBuf,
+
+    /// Path to output info TOML.
+    #[arg(
+        long,
+        value_name = "FILE",
+        value_parser,
+        default_value = "payload.toml"
+    )]
+    output_info: PathBuf,
+
+    /// Path to output images directory.
+    #[arg(
+        long,
+        value_name = "DIR",
+        value_parser,
+        default_value = "payload_images"
+    )]
+    output_images: PathBuf,
+}
+
+/// Pack a payload binary.
+///
+/// The new payload binary will *only* contain images listed in the info TOML
+/// file. Extra images in the input images directory that aren't listed will be
+/// silently ignored. Images are added to the payload in the order that they are
+/// listed in the info TOML file.
+#[derive(Debug, Parser)]
+struct PackCli {
+    /// Path to output payload binary.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    output: PathBuf,
+
+    /// Path to output payload properties file.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    output_properties: Option<PathBuf>,
+
+    /// Path to input info TOML.
+    #[arg(
+        long,
+        value_name = "FILE",
+        value_parser,
+        default_value = "payload.toml"
+    )]
+    input_info: PathBuf,
+
+    /// Path to input images directory.
+    #[arg(
+        long,
+        value_name = "DIR",
+        value_parser,
+        default_value = "payload_images"
+    )]
+    input_images: PathBuf,
+
+    #[command(flatten)]
+    key: KeyGroup,
+}
+
+/// Repack a payload binary.
+///
+/// This command is equivalent to running `unpack` and `pack`, except without
+/// storing the unpacked data to disk nor recompressing the partition images.
+#[derive(Debug, Parser)]
+struct RepackCli {
+    /// Path to input payload binary.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    input: PathBuf,
+
+    /// Path to output payload binary.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    output: PathBuf,
+
+    /// Path to output payload properties file.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    output_properties: Option<PathBuf>,
+
+    #[command(flatten)]
+    key: KeyGroup,
 }
 
 /// Display payload information.
@@ -38,6 +455,9 @@ struct InfoCli {
 
 #[derive(Debug, Subcommand)]
 enum PayloadCommand {
+    Unpack(UnpackCli),
+    Pack(PackCli),
+    Repack(RepackCli),
     Info(InfoCli),
 }
 
@@ -46,4 +466,8 @@ enum PayloadCommand {
 pub struct PayloadCli {
     #[command(subcommand)]
     command: PayloadCommand,
+
+    /// Don't print payload header information.
+    #[arg(short, long, global = true)]
+    quiet: bool,
 }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -688,7 +688,7 @@ fn create_payload(
             .with_context(|| format!("Failed to copy from image: {name}"))?;
     }
 
-    let (_, properties, metadata_size) = payload_writer
+    let (_, _, properties, metadata_size) = payload_writer
         .finish()
         .context("Failed to finalize payload")?;
 


### PR DESCRIPTION
Some devices have "full" OTAs where the payload is missing the recovery partition. These subcommands make it possible to manually add back the missing image. Given the strict requirements for how the OTA zip is laid out and signed, users can't just replace `payload.bin` in a zip and call it a day, but it's sufficient for feeding a modified input to `avbroot ota patch`.

Issue: #328