### PR TITLE
Print a useful error message when there's no TTY for a password prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "flate2",
  "gf256",
  "hex",
+ "libc",
  "liblzma",
  "lz4_flex",
  "memchr",
@@ -823,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "liblzma"

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -69,6 +69,7 @@ default-features = false
 features = ["deflate"]
 
 [target.'cfg(unix)'.dependencies]
+libc = "0.2.158"
 rustix = { version = "0.38.9", default-features = false, features = ["process"] }
 
 [build-dependencies]


### PR DESCRIPTION
`ENXIO` (No such device or address) and `ENOTTY` (Inappropriate ioctl for device) are not very user-friendly error messages.

Issue: https://github.com/chenxiaolong/my-avbroot-setup/issues/2