### PR TITLE
Add support for outputting zip files with no data descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,12 @@ avbroot ota extract \
     --all
 ```
 
+### Zip write mode
+
+By default, avbroot uses streaming writes for the output OTA during patching. This means it computes the sha256 digest for the digital signature as the file is being written. This mode causes the zip file to contain data descriptors, which is part of the zip standard and works on the vast majority of devices. However, some devices may have broken zip file parsers and fail to properly read OTA zip files containing data descriptors. If this is the case, pass in `--zip-mode seekable` when patching.
+
+The seekable mode writes zip files without data descriptors, but as the name implies, requires seeking around the file instead of writing it sequentially. The sha256 digest for the digital signature is computed after the zip file has been fully written.
+
 ### Signing with an external program
 
 avbroot supports delegating all RSA signing operations to an external program with the `--signing-helper` option. When using this option, the `--key-avb` and `--key-ota` options must be given a public key instead of a private key.

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -48,9 +48,13 @@ data.type = "boot"
 data.version = "vendor_v4"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
-[profile.pixel_v4_gki.hashes]
+[profile.pixel_v4_gki.hashes_streaming]
 original = "c00f891f941f3dddb28966f7b07f3acea773bee104dace82b37c2d1341f09422"
 patched = "ce9d8ee97828d233809742a5d3f23aa27b042675b1935ca9e3df0592c55788fd"
+
+[profile.pixel_v4_gki.hashes_seekable]
+original = "96a6c366b5de1c3b10d4d6cb4ca503c83ac4cd9ca952a965cceb041990ba7022"
+patched = "e7b4609ba7a23609211dcae143bc43f091f286fbbb3a9301c02ee25614d35deb"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -85,9 +89,13 @@ data.type = "boot"
 data.version = "vendor_v4"
 data.ramdisks = [["init", "otacerts", "first_stage", "dsu_key_dir"], ["dlkm"]]
 
-[profile.pixel_v4_non_gki.hashes]
+[profile.pixel_v4_non_gki.hashes_streaming]
 original = "4d692bc777b568b0626d3c08d2e6f83f1b472db5ad903486daaec6a78d0cc26e"
 patched = "e27673e4f30933710c11d51f0e73849068cbe9bc9f54e6076bdd93f9a5c8ea0a"
+
+[profile.pixel_v4_non_gki.hashes_seekable]
+original = "ea27ecd9718c17b63400b2548680bb3cee93ce63b4fc44ff9654ca0d9c5372a8"
+patched = "3456b14e014cf565a808a9e834d9105a23539f07b2c460db19c9384aadbc3b93"
 
 # Google Pixel 4a 5G
 # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -123,9 +131,13 @@ data.type = "boot"
 data.version = "vendor_v3"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
-[profile.pixel_v3.hashes]
+[profile.pixel_v3.hashes_streaming]
 original = "f432dc7931520feb238474aa707dd5299747562ffe6129f3f763b5f11ac473ab"
 patched = "3850a2e73bd783a1ec4a70c59f37d2374e017c20df7ab4b591182b14d187c18e"
+
+[profile.pixel_v3.hashes_seekable]
+original = "7d29ecc6780953c22052a576b8dc85066c8667a875e918a786a08ff4545b47d1"
+patched = "9f6342940b7cfbeb27b0567f006bb35cbee910ef038ec535403c662d5252ca71"
 
 # Google Pixel 4a
 # What's unique: boot (boot v2)
@@ -155,6 +167,10 @@ avb.signed = true
 data.type = "vbmeta"
 data.deps = ["system"]
 
-[profile.pixel_v2.hashes]
+[profile.pixel_v2.hashes_streaming]
 original = "1b45235b58054009cc496f6c3ee11d3dc16ed5c388c861761e26a6fce83103a0"
 patched = "193b2dc70dd465d686f35c7b7f74d2cc1b06a55e48cf5c2e4df0f667e03032fc"
+
+[profile.pixel_v2.hashes_seekable]
+original = "52284308fae10cbaf09ade14e92f3bbe6149751a42bff15432982fcef8d890ab"
+patched = "7ad74ac87ddcaf34938017e6149a646041d70926e31ecda93e156e9397467b3b"

--- a/e2e/src/config.rs
+++ b/e2e/src/config.rs
@@ -112,7 +112,8 @@ pub struct Partition {
 pub struct Profile {
     pub vabc_algo: Option<VabcAlgo>,
     pub partitions: BTreeMap<String, Partition>,
-    pub hashes: Hashes,
+    pub hashes_streaming: Hashes,
+    pub hashes_seekable: Hashes,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
This commit adds a new `--zip-mode` parameter to `avbroot ota patch` to control whether the patched OTA zip is written with data descriptors or not. By default, the `streaming` mode is used, which matches the current behavior where the zip is hashed for signing as it is being written. The new `seekable` mode fully writes the zip before rereading it to hash the contents.

The new mode is useful for devices with broken zip parsers that fail to properly handle data descriptors.

All of the end-to-end tests have been duplicated to test both modes.

Adding the seekable mode necessitated a couple other changes:

* BufWriter is no longer used. Type erasure is very painful in Rust, so we need to keep the writer types the same for both the streaming and seekable modes. BufWriter is unusable in the seekable mode because we need to be able to read back what was written, which isn't supported.

* HolePunchingWriter has been removed. It was a simple way to produce sparse files by seeking whenever a write buffer consists fully of zeros. When combined with BufWriter, there was previously never a situation where this was undesirable. However, with the new seekable mode and the zip library's pattern of writing one field at a time, the final 2 zero bytes (representing an empty archive comment) is never written and the file size is not increased either.

  Removing this is not a big deal since we no longer use stripped OTAs for the end-to-end tests. Those were really the only OTAs that benefitted from sparse files. A real OTA has very few zero bytes due to compression.

Issue: #328