### PR TITLE
Return ExitCode from main

### DIFF
--- a/avbroot/src/main.rs
+++ b/avbroot/src/main.rs
@@ -3,16 +3,19 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    process::ExitCode,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use tracing::error;
 
 static LOGGING_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-fn main() {
+fn main() -> ExitCode {
     // Set up a cancel signal so we can properly clean up any temporary files.
     let cancel_signal = Arc::new(AtomicBool::new(false));
     {
@@ -25,14 +28,14 @@ fn main() {
     }
 
     match avbroot::cli::args::main(&LOGGING_INITIALIZED, &cancel_signal) {
-        Ok(_) => {}
+        Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
             if LOGGING_INITIALIZED.load(Ordering::SeqCst) {
                 error!("{e:?}");
             } else {
                 eprintln!("{e:?}");
             }
-            std::process::exit(1);
+            ExitCode::FAILURE
         }
     }
 }


### PR DESCRIPTION
`std::process::exit()` calls the exit syscall, which doesn't run destructors. It doesn't matter for avbroot, but better to use `ExitCode` anyway.