### PR TITLE
ci.yml: Use target name in Rust cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.artifact.name }}
 
       - name: Clippy
         shell: bash


### PR DESCRIPTION
Otherwise, the x86_64-unknown-linux-gnu build running on Ubuntu 22.04 can use the cache from the aarch64-linux-android31 build that originally ran on Ubuntu 24.04. This fails due to some cached components having been compiled against a newer version of glibc.