### PR TITLE
Add option to skip inserting OTA cert into recovery image

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ Note that avbroot will validate that the prepatched image is compatible with the
 
 avbroot can be used for just re-signing an OTA by specifying `--rootless` instead of `--magisk`/`--prepatched`. With this option, the patched OTA will not be rooted. The only modification applied is the replacement of the OTA verification certificate so that the OS can be upgraded with future (patched) OTAs.
 
+### Skipping recovery OTA certificate patches
+
+avbroot can skip modifying `otacerts.zip` in the recovery image with the `--skip-recovery-ota-cert` option. **Do not do this unless you have a good reason to do so.** (For example, if you've already manually inserted the OTA certificate into a boot image specified with `--prepatched` or `--replace`.) When this option is used with `--rootless` (and `--dsu` is not specified), then no modifications are performed on any boot image besides ensuring they are properly signed.
+
+When manually adding the OTA certificate to a boot image, [verifying the patched OTA](#verifying-otas) afterwards is recommended to ensure that it was properly done.
+
 ### Replacing partitions
 
 avbroot supports replacing entire partitions in the OTA, even partitions that are not boot images (eg. `vendor_dlkm`). A partition can be replaced by passing in `--replace <partition name> /path/to/partition.img`.

--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -1134,6 +1134,11 @@ pub fn patch_boot_images<'a>(
 ) -> Result<HashSet<&'a str>> {
     let parent_span = Span::current();
 
+    if patchers.is_empty() {
+        debug!("Skip loading boot images; nothing to patch");
+        return Ok(HashSet::new());
+    }
+
     // Preparse all images. Some patchers need to inspect every candidate.
     let mut images = load_boot_images(names, open_input)?;
 


### PR DESCRIPTION
Issue: #366