### PR TITLE
format/payload: Allow verifying signatures without an unpadded size

### DIFF
--- a/avbroot/src/format/payload.rs
+++ b/avbroot/src/format/payload.rs
@@ -206,10 +206,10 @@ fn verify_digest(digest: &[u8], signatures: &Signatures, cert: &Certificate) -> 
         let Some(data) = &signature.data else {
             continue;
         };
-        let Some(size) = signature.unpadded_signature_size else {
-            continue;
-        };
-        let without_padding = &data[..size as usize];
+        let size = signature
+            .unpadded_signature_size
+            .map_or(data.len(), |s| s as usize);
+        let without_padding = &data[..size];
 
         match public_key.verify_sig(SignatureAlgorithm::Sha256WithRsa, digest, without_padding) {
             Ok(_) => return Ok(()),


### PR DESCRIPTION
Older OTAs created before the payload metadata format supported EC signatures will not have the `unpadded_signature_size` field set. In this case, we'll just use the full length of `data`, which is what update_engine also does.

Issue: #366