### PR TITLE
Improve parser error messages

### DIFF
--- a/avbroot/src/patch/system.rs
+++ b/avbroot/src/patch/system.rs
@@ -33,8 +33,8 @@ pub enum Error {
     NoFooter,
     #[error("No hash tree descriptor found in vbmeta header")]
     NoHashTreeDescriptor,
-    #[error("{0:?} field is out of bounds")]
-    FieldOutOfBounds(&'static str),
+    #[error("{0:?} overflowed integer bounds during calculations")]
+    IntOverflow(&'static str),
     #[error("AVB error")]
     Avb(#[from] avb::Error),
     #[error("OTA certificate error")]
@@ -215,15 +215,15 @@ pub fn patch_system_image(
     let hash_tree_end = descriptor
         .tree_offset
         .checked_add(descriptor.tree_size)
-        .ok_or_else(|| Error::FieldOutOfBounds("hash_tree_end"))?;
+        .ok_or_else(|| Error::IntOverflow("hash_tree_end"))?;
     let fec_data_end = descriptor
         .fec_offset
         .checked_add(descriptor.fec_size)
-        .ok_or_else(|| Error::FieldOutOfBounds("fec_data_end"))?;
+        .ok_or_else(|| Error::IntOverflow("fec_data_end"))?;
     let header_end = footer
         .vbmeta_offset
         .checked_add(footer.vbmeta_size)
-        .ok_or_else(|| Error::FieldOutOfBounds("avb_end"))?;
+        .ok_or_else(|| Error::IntOverflow("avb_end"))?;
     let footer_start = image_size - Footer::SIZE as u64;
 
     let other_ranges = util::merge_overlapping(&[

--- a/avbroot/src/util.rs
+++ b/avbroot/src/util.rs
@@ -1,9 +1,15 @@
-// SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{cmp::Ordering, fmt, ops::Range, path::Path};
+use std::{
+    cmp::Ordering,
+    fmt, mem,
+    ops::{Bound, Range, RangeBounds},
+    path::Path,
+};
 
-use num_traits::PrimInt;
+use num_traits::{NumCast, PrimInt};
+use thiserror::Error;
 
 pub const ZEROS: [u8; 16384] = [0u8; 16384];
 
@@ -19,6 +25,172 @@ impl<T: PrimInt + fmt::Debug> fmt::Debug for NumBytes<T> {
             write!(f, "<{:?} bytes>", self.0)
         }
     }
+}
+
+/// Stores a precomputed [`Debug`] string.
+#[derive(Clone)]
+pub struct DebugString(String);
+
+impl DebugString {
+    pub fn new(value: impl fmt::Debug) -> Self {
+        Self(format!("{value:?}"))
+    }
+}
+
+impl fmt::Debug for DebugString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A single bound in a range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntBound<T: PrimInt> {
+    Included(T),
+    Excluded(T),
+}
+
+/// A bounded primitive integer range. Unlike std's range types, this is a
+/// single type that can represent open, closed, and half-open intervals.
+#[derive(Clone, Copy, Debug)]
+pub struct IntRange<T: PrimInt> {
+    pub start: IntBound<T>,
+    pub end: IntBound<T>,
+}
+
+impl<T: PrimInt> IntRange<T> {
+    /// Returns [`None`] if the range bounds cannot be represented by `T`. If
+    /// the start and end of `range` are unbounded, then it gets converted to
+    /// [`IntBound::Included`] with `N`'s minimum or maximum value.
+    pub fn new<N: PrimInt, R: RangeBounds<N>>(range: R) -> Option<Self> {
+        let start = match range.start_bound() {
+            Bound::Included(n) => IntBound::Included(T::from(*n)?),
+            Bound::Excluded(n) => IntBound::Excluded(T::from(*n)?),
+            Bound::Unbounded => IntBound::Included(T::from(N::min_value())?),
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(n) => IntBound::Included(T::from(*n)?),
+            Bound::Excluded(n) => IntBound::Excluded(T::from(*n)?),
+            Bound::Unbounded => IntBound::Included(T::from(N::max_value())?),
+        };
+
+        Some(Self { start, end })
+    }
+}
+
+impl<T: PrimInt + fmt::Display> fmt::Display for IntRange<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.start {
+            IntBound::Included(n) => write!(f, "[{n}, ")?,
+            IntBound::Excluded(n) => write!(f, "({n}, ")?,
+        }
+
+        match self.end {
+            IntBound::Included(n) => write!(f, "{n}]"),
+            IntBound::Excluded(n) => write!(f, "{n})"),
+        }
+    }
+}
+
+/// A non-generic type that can represent any 64-bit or smaller primitive
+/// integer.
+#[derive(Clone, Copy, Debug)]
+pub enum LargeInt {
+    Signed(i64),
+    Unsigned(u64),
+}
+
+impl fmt::Display for LargeInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Signed(n) => n.fmt(f),
+            Self::Unsigned(n) => n.fmt(f),
+        }
+    }
+}
+
+/// A non-generic type that can represent any 64-bit or smaller primitive
+/// integer range.
+#[derive(Clone, Copy, Debug)]
+pub enum LargeIntRange {
+    Signed(IntRange<i64>),
+    Unsigned(IntRange<u64>),
+}
+
+impl fmt::Display for LargeIntRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Signed(r) => r.fmt(f),
+            Self::Unsigned(r) => r.fmt(f),
+        }
+    }
+}
+
+/// An error returned when a value is not within a specific range.
+#[derive(Clone, Copy, Debug, Error)]
+#[error("Integer value {value} not in bounds: {range}")]
+pub struct OutOfBoundsError {
+    value: LargeInt,
+    range: LargeIntRange,
+}
+
+/// Verify that `value` is within `bounds` and then return `value` if it is.
+pub fn check_bounds<T: PrimInt>(
+    value: T,
+    bounds: impl RangeBounds<T>,
+) -> Result<T, OutOfBoundsError> {
+    const {
+        assert!(
+            mem::size_of::<T>() <= 8,
+            "Integer must be 64 bits or smaller"
+        );
+    }
+
+    if !bounds.contains(&value) {
+        let value = if T::min_value() != T::zero() {
+            LargeInt::Signed(NumCast::from(value).unwrap())
+        } else {
+            LargeInt::Unsigned(NumCast::from(value).unwrap())
+        };
+
+        let range = if T::min_value() != T::zero() {
+            LargeIntRange::Signed(IntRange::new(bounds).unwrap())
+        } else {
+            LargeIntRange::Unsigned(IntRange::new(bounds).unwrap())
+        };
+
+        return Err(OutOfBoundsError { value, range });
+    }
+
+    Ok(value)
+}
+
+/// Try to cast `value` to primitive integer type `T`. If it does not fit, the
+/// error will indicate the valid range of values.
+pub fn try_cast<T: PrimInt, V: PrimInt>(value: V) -> Result<T, OutOfBoundsError> {
+    const {
+        assert!(
+            mem::size_of::<T>() <= 8,
+            "Integer must be 64 bits or smaller"
+        );
+    }
+
+    NumCast::from(value).ok_or_else(|| {
+        let value = if V::min_value() != V::zero() {
+            LargeInt::Signed(NumCast::from(value).unwrap())
+        } else {
+            LargeInt::Unsigned(NumCast::from(value).unwrap())
+        };
+
+        let range = if T::min_value() != T::zero() {
+            LargeIntRange::Signed(IntRange::new::<T, _>(..).unwrap())
+        } else {
+            LargeIntRange::Unsigned(IntRange::new::<T, _>(..).unwrap())
+        };
+
+        OutOfBoundsError { value, range }
+    })
 }
 
 /// Check if a byte slice is all zeros.
@@ -115,7 +287,67 @@ where
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use super::*;
+
+    #[test]
+    fn test_int_range() {
+        let range = IntRange::new::<u8, _>(..).unwrap();
+        assert_eq!(range.start, IntBound::Included(u8::MIN));
+        assert_eq!(range.end, IntBound::Included(u8::MAX));
+
+        let range = IntRange::<i8>::new(-2i16..2i16).unwrap();
+        assert_eq!(range.start, IntBound::Included(-2));
+        assert_eq!(range.end, IntBound::Excluded(2));
+
+        assert!(IntRange::<u8>::new::<u16, _>(..).is_none());
+    }
+
+    #[test]
+    fn test_check_bounds() {
+        check_bounds(i64::MIN, ..).unwrap();
+        check_bounds(i64::MAX, ..).unwrap();
+        check_bounds(u64::MIN, ..).unwrap();
+        check_bounds(u64::MAX, ..).unwrap();
+        check_bounds(0, -1..=1).unwrap();
+
+        let err = check_bounds(i8::MAX, 0..=0).unwrap_err();
+        assert_matches!(err.value, LargeInt::Signed(127));
+        assert_matches!(
+            err.range,
+            LargeIntRange::Signed(IntRange {
+                start: IntBound::Included(0),
+                end: IntBound::Included(0),
+            })
+        );
+
+        let err = check_bounds(u8::MAX, 0..=0).unwrap_err();
+        assert_matches!(err.value, LargeInt::Unsigned(255));
+        assert_matches!(
+            err.range,
+            LargeIntRange::Unsigned(IntRange {
+                start: IntBound::Included(0),
+                end: IntBound::Included(0),
+            })
+        );
+    }
+
+    #[test]
+    fn test_try_cast() {
+        let value: u8 = try_cast(255u16).unwrap();
+        assert_eq!(value, 255);
+
+        let err = try_cast::<i8, _>(256u16).unwrap_err();
+        assert_matches!(err.value, LargeInt::Unsigned(256));
+        assert_matches!(
+            err.range,
+            LargeIntRange::Signed(IntRange {
+                start: IntBound::Included(-128),
+                end: IntBound::Included(127),
+            })
+        );
+    }
 
     #[test]
     fn test_ranges_overlaps() {


### PR DESCRIPTION
* Remove the `ReadString` trait and perform UTF-8 conversions explicitly. UTF-8 conversion errors are now individual errors instead of being hidden in an `Io` error.
* Add new `IntOutOfBounds` errors that include the actual field value and the range of values that are valid for the field. Integer casting also uses this error type where possible.
* Replace remaining uses of `FieldOutOfBounds` with `IntOverflow`, which is returned when checked arithmetic fails. For code simplicity, it does not store intermediate values.
* Replace `ReadFieldError` and `WriteFieldError` with the generic `Io` error to simplify the code. They were used inconsistently anyway.
* Use fully qualified field names in `avb` and `bootimage` error messages since the same name frequently appears in multiple structs.
* Replace `InvalidFieldValue` with more specific errors in `bootimage`.
* Replace all stringly-typed errors in `lp` and `sparse` with (very) specific errors.
* Fix the wording in a number of errors.
* Add new `ReadFixedSizeExt` trait for reading fixed size arrays and vecs from `Read` types.
* Remove some fallible casts from `u32` to `usize` and from `usize` to `u64`. avbroot only supports 32-bit and 64-bit systems anyway.