### PR TITLE
Add support for Magisk 28100

### DIFF
--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -151,7 +151,7 @@ impl MagiskRootPatcher {
     //   RULESDEVICE config option, which stored the writable block device as an
     //   rdev major/minor pair, which was not consistent across reboots and was
     //   replaced by PREINITDEVICE
-    const VERS_SUPPORTED: &'static [Range<u32>] = &[25102..25207, 25211..28100];
+    const VERS_SUPPORTED: &'static [Range<u32>] = &[25102..25207, 25211..28200];
     const VER_PREINIT_DEVICE: Range<u32> =
         25211..Self::VERS_SUPPORTED[Self::VERS_SUPPORTED.len() - 1].end;
     const VER_RANDOM_SEED: Range<u32> = 25211..26103;


### PR DESCRIPTION
There is nothing new that breaks compatibility with avbroot.

Fixes: #389