### PR TITLE
Update bzip2-rs to 0.5.0 and switch to Rust backend implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,17 +234,18 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
-source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=6e0f9836ec87b19261461b6cc1772e14aff8e851#6e0f9836ec87b19261461b6cc1772e14aff8e851"
+version = "0.5.0"
+source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=554b916bf68d246fe20b4c7da509d8a3c4e66e5f#554b916bf68d246fe20b4c7da509d8a3c4e66e5f"
 dependencies = [
  "bzip2-sys",
+ "libbz2-rs-sys",
  "libc",
 ]
 
 [[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
-source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=6e0f9836ec87b19261461b6cc1772e14aff8e851#6e0f9836ec87b19261461b6cc1772e14aff8e851"
+source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=554b916bf68d246fe20b4c7da509d8a3c4e66e5f#554b916bf68d246fe20b4c7da509d8a3c4e66e5f"
 dependencies = [
  "cc",
  "libc",
@@ -827,6 +828,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55bbb91f13e5136d00496b884cdb605fb983d6f964c8735bc5837d1c98550fd5"
 
 [[package]]
 name = "libc"

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -57,12 +57,12 @@ x509-cert = { version = "0.2.4", features = ["builder"] }
 zerocopy = { version = "0.8.10", features = ["std"] }
 zerocopy-derive = "0.8.5"
 
-# There are multiple upstream bugs that cause infinite loops in the Drop
-# implementation of write::BzDecoder. Unfortunately, the project is no longer
-# maintained, so we have to maintain our own fork with the necessary fixes.
+# https://github.com/trifectatechfoundation/bzip2-rs/pull/118
 [dependencies.bzip2]
 git = "https://github.com/chenxiaolong/bzip2-rs"
-rev = "6e0f9836ec87b19261461b6cc1772e14aff8e851"
+rev = "554b916bf68d246fe20b4c7da509d8a3c4e66e5f"
+default-features = false
+features = ["libbz2-rs-sys"]
 
 # https://github.com/zip-rs/zip/pull/383
 [dependencies.zip]

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
+    "bzip2-1.0.6",
     "GPL-3.0",
     "ISC",
     "MIT",


### PR DESCRIPTION
The bzip2-rs library now has a new maintainer (same folks that maintain the sudo-rs project). Version 0.5.0 was recently released, which includes some much needed bug fixes, but is missing one final one, so we still need to keep our fork for now.

This commit also switches the backend implementation from the official C implementation to a Rust implementation maintained by the bzip2-rs folks. This leaves xz as the only C dependency remaining in avbroot.