### PR TITLE
Switch to upstream master branch of bzip2-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,21 +235,10 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 [[package]]
 name = "bzip2"
 version = "0.5.0"
-source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=554b916bf68d246fe20b4c7da509d8a3c4e66e5f#554b916bf68d246fe20b4c7da509d8a3c4e66e5f"
+source = "git+https://github.com/trifectatechfoundation/bzip2-rs?rev=15258feb0cdc1114d6fc6b936254c4f4e1d5730c#15258feb0cdc1114d6fc6b936254c4f4e1d5730c"
 dependencies = [
- "bzip2-sys",
  "libbz2-rs-sys",
  "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "git+https://github.com/chenxiaolong/bzip2-rs?rev=554b916bf68d246fe20b4c7da509d8a3c4e66e5f#554b916bf68d246fe20b4c7da509d8a3c4e66e5f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -57,10 +57,10 @@ x509-cert = { version = "0.2.4", features = ["builder"] }
 zerocopy = { version = "0.8.10", features = ["std"] }
 zerocopy-derive = "0.8.5"
 
-# https://github.com/trifectatechfoundation/bzip2-rs/pull/118
+# Waiting for next stable release.
 [dependencies.bzip2]
-git = "https://github.com/chenxiaolong/bzip2-rs"
-rev = "554b916bf68d246fe20b4c7da509d8a3c4e66e5f"
+git = "https://github.com/trifectatechfoundation/bzip2-rs"
+rev = "15258feb0cdc1114d6fc6b936254c4f4e1d5730c"
 default-features = false
 features = ["libbz2-rs-sys"]
 
@@ -84,7 +84,7 @@ protox = "0.7.0"
 assert_matches = "1.5.0"
 
 [features]
-static = ["bzip2/static", "liblzma/static"]
+static = ["liblzma/static"]
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -69,6 +69,6 @@ bypass = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
-    "https://github.com/chenxiaolong/bzip2-rs",
     "https://github.com/chenxiaolong/zip",
+    "https://github.com/trifectatechfoundation/bzip2-rs",
 ]


### PR DESCRIPTION
The only remaining fix from our fork has been merged. This can be switched to a stable release after the next release.