### PR TITLE
cli/ota: Add support for extracting specific images

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,7 @@ Magisk versions 25211 and newer require a writable partition for storing custom 
     ```bash
     avbroot ota extract \
         --input /path/to/ota.zip \
-        --directory . \
-        --boot-only
+        --partition <name> # init_boot or boot, depending on device
     ```
 
 2. Patch the boot image via the Magisk app. This **MUST** be done on the target device or a device of the same model! The partition name will be incorrect if patched from Magisk on a different device model.


### PR DESCRIPTION
Previously, we only supported extracting all images or the subset of images that could potentially be patched by avbroot. This was unnecessarily slow if the user only needed to extract a specific image.

This commit also deprecates and hides the `--boot-only` option, though the functionality will remain indefinitely.