### PR TITLE
cli/ota: Add support for extracting OTA certificate and AVB public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,16 +450,19 @@ avbroot prompts for the private key passphrases interactively by default. To run
 
 * Use unencrypted private keys. This is strongly discouraged.
 
-### Extracting the entire OTA
+### Extracting an OTA
 
-To extract all images contained within the OTA's `payload.bin`, run:
+To extract the partition images contained within an OTA's `payload.bin`, run:
 
 ```bash
 avbroot ota extract \
     --input /path/to/ota.zip \
-    --directory extracted \
-    --all
+    --directory extracted
 ```
+
+By default, this only extracts the images that could potentially be patched by avbroot. To extract all images, use the `--all` option. To extract specific images, use the `--partition <name>` option, which can be specified multiple times.
+
+This command also supports extracting the embedded OTA certificate and AVB public key using the `--cert-ota` and `--public-key-avb` options. To extract only these components, pass in `--none` to skip extracting partition images.
 
 ### Zip write mode
 

--- a/avbroot/src/crypto.rs
+++ b/avbroot/src/crypto.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
@@ -686,21 +686,17 @@ pub fn parse_cms(data: &[u8]) -> Result<SignedData> {
     Ok(sd)
 }
 
-/// Get a list of all standard X509 certificates contained within a
+/// Get an iterator to all standard X509 certificates contained within a
 /// [`SignedData`] structure.
-pub fn get_cms_certs(sd: &SignedData) -> Vec<Certificate> {
-    sd.certificates.as_ref().map_or_else(Vec::new, |certs| {
-        certs
-            .0
-            .iter()
-            .filter_map(|cc| {
-                if let CertificateChoices::Certificate(c) = cc {
-                    Some(c.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
+pub fn iter_cms_certs(sd: &SignedData) -> impl Iterator<Item = &Certificate> {
+    sd.certificates.iter().flat_map(|certs| {
+        certs.0.iter().filter_map(|cc| {
+            if let CertificateChoices::Certificate(c) = cc {
+                Some(c)
+            } else {
+                None
+            }
+        })
     })
 }
 


### PR DESCRIPTION
This also adds a new `--none` option so that these two components can be extracted without extracting any partition images.