### PR TITLE
Switch to stable bzip2-rs release and use zlib-rs flate2 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,6 @@ dependencies = [
  "liblzma",
  "lz4_flex",
  "memchr",
- "miniz_oxide",
  "num-bigint-dig",
  "num-traits",
  "passterm",
@@ -235,10 +234,23 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bzip2"
-version = "0.5.0"
-source = "git+https://github.com/trifectatechfoundation/bzip2-rs?rev=09a87db73c0517a9715ab3fd96fbe4961d545aee#09a87db73c0517a9715ab3fd96fbe4961d545aee"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b89e7c29231c673a61a46e722602bcd138298f6b9e81e71119693534585f5c"
 dependencies = [
+ "bzip2-sys",
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.12+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -399,9 +411,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constcat"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4938185353434999ef52c81753c8cca8955ed38042fc29913db3751916f3b7ab"
+checksum = "5ffb5df6dd5dadb422897e8132f415d7a054e3cd757e5070b663f75bea1840fb"
 
 [[package]]
 name = "cpufeatures"
@@ -617,6 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -820,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bbb91f13e5136d00496b884cdb605fb983d6f964c8735bc5837d1c98550fd5"
+checksum = "0864a00c8d019e36216b69c2c4ce50b83b7bd966add3cf5ba554ec44f8bebcf5"
 
 [[package]]
 name = "libc"
@@ -855,6 +868,15 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2081,3 +2103,9 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.75"
 base64 = "0.22.1"
 bitflags = { version = "2.4.1", features = ["serde"] }
 bstr = "1.6.2"
+bzip2 = { version = "0.5.1", default-features = false, features = ["libbz2-rs-sys"] }
 cap-std = "3.0.0"
 cap-tempfile = "3.0.0"
 clap = { version = "4.4.1", features = ["derive"] }
@@ -22,19 +23,19 @@ const-oid = "0.9.5"
 crc32fast = "1.4.2"
 ctrlc = "3.4.0"
 dlv-list = "0.6.0"
-flate2 = "1.0.27"
+flate2 = { version = "1.0.29", features = ["zlib-rs"] }
 gf256 = { version = "0.3.0", features = ["rs"] }
 hex = { version = "0.4.3", features = ["serde"] }
 liblzma = "0.3.0"
 lz4_flex = "0.11.1"
 memchr = "2.6.0"
-miniz_oxide = "0.8.0"
 num-bigint-dig = "0.8.4"
 num-traits = "0.2.16"
 passterm = "2.0.3"
 phf = { version = "0.11.2", features = ["macros"] }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pem"] }
 prost = "0.13.1"
+# We can't upgrade to 0.9.0 until rsa updates its rand_core dependency.
 rand = "0.8.5"
 rayon = "1.7.0"
 regex = { version = "1.9.4", default-features = false, features = ["perf", "std"] }
@@ -57,13 +58,6 @@ x509-cert = { version = "0.2.4", features = ["builder"] }
 zerocopy = { version = "0.8.10", features = ["std"] }
 zerocopy-derive = "0.8.5"
 
-# Waiting for next stable release.
-[dependencies.bzip2]
-git = "https://github.com/trifectatechfoundation/bzip2-rs"
-rev = "09a87db73c0517a9715ab3fd96fbe4961d545aee"
-default-features = false
-features = ["libbz2-rs-sys"]
-
 # https://github.com/zip-rs/zip/pull/383
 [dependencies.zip]
 git = "https://github.com/chenxiaolong/zip"
@@ -76,7 +70,7 @@ libc = "0.2.158"
 rustix = { version = "0.38.9", default-features = false, features = ["process"] }
 
 [build-dependencies]
-constcat = "0.5.0"
+constcat = "0.6.0"
 prost-build = "0.13.1"
 protox = "0.7.0"
 

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,12 @@ ignore = [
     # avbroot has no network capabilities, so this is not inherently remotely
     # exploitable.
     "RUSTSEC-2023-0071",
+
+    # https://rustsec.org/advisories/RUSTSEC-2025-0007
+    #
+    # Temporarily allow this until we can switch our SHA-256 hashing operations
+    # to using another library.
+    "RUSTSEC-2025-0007",
 ]
 
 [licenses]
@@ -39,6 +45,7 @@ allow = [
     "MIT",
     "OpenSSL",
     "Unicode-3.0",
+    "Zlib",
 ]
 
 [[licenses.clarify]]
@@ -70,5 +77,4 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
     "https://github.com/chenxiaolong/zip",
-    "https://github.com/trifectatechfoundation/bzip2-rs",
 ]

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -50,11 +50,11 @@ data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v4_gki.hashes_streaming]
 original = "c00f891f941f3dddb28966f7b07f3acea773bee104dace82b37c2d1341f09422"
-patched = "ce9d8ee97828d233809742a5d3f23aa27b042675b1935ca9e3df0592c55788fd"
+patched = "6c27ffb07f4497af8539f8283e506066af9417580230c3209c9875fc15d5069d"
 
 [profile.pixel_v4_gki.hashes_seekable]
 original = "96a6c366b5de1c3b10d4d6cb4ca503c83ac4cd9ca952a965cceb041990ba7022"
-patched = "e7b4609ba7a23609211dcae143bc43f091f286fbbb3a9301c02ee25614d35deb"
+patched = "e4fc12523ffc312796b92210bc1e3bbb70dd60797a47daae76c8b5852e48b382"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -91,11 +91,11 @@ data.ramdisks = [["init", "otacerts", "first_stage", "dsu_key_dir"], ["dlkm"]]
 
 [profile.pixel_v4_non_gki.hashes_streaming]
 original = "4d692bc777b568b0626d3c08d2e6f83f1b472db5ad903486daaec6a78d0cc26e"
-patched = "e27673e4f30933710c11d51f0e73849068cbe9bc9f54e6076bdd93f9a5c8ea0a"
+patched = "6832ded3e98a14edc8c5ea7284fcea0b958fa710ebf222c27116faec8dfefe2e"
 
 [profile.pixel_v4_non_gki.hashes_seekable]
 original = "ea27ecd9718c17b63400b2548680bb3cee93ce63b4fc44ff9654ca0d9c5372a8"
-patched = "3456b14e014cf565a808a9e834d9105a23539f07b2c460db19c9384aadbc3b93"
+patched = "114f8936e917d7e4a71bc1521adb3c8e676de3a738f8c7c505b86464d20bd95c"
 
 # Google Pixel 4a 5G
 # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -133,11 +133,11 @@ data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v3.hashes_streaming]
 original = "f432dc7931520feb238474aa707dd5299747562ffe6129f3f763b5f11ac473ab"
-patched = "3850a2e73bd783a1ec4a70c59f37d2374e017c20df7ab4b591182b14d187c18e"
+patched = "1f28d9210a17e233cd5da4af55b07db764b19eeab991394514170b405240464f"
 
 [profile.pixel_v3.hashes_seekable]
 original = "7d29ecc6780953c22052a576b8dc85066c8667a875e918a786a08ff4545b47d1"
-patched = "9f6342940b7cfbeb27b0567f006bb35cbee910ef038ec535403c662d5252ca71"
+patched = "27b80c7be9c1e527ea26abe3dabde245c580e6f26ec084204278fbfd81a39f83"
 
 # Google Pixel 4a
 # What's unique: boot (boot v2)
@@ -168,9 +168,9 @@ data.type = "vbmeta"
 data.deps = ["system"]
 
 [profile.pixel_v2.hashes_streaming]
-original = "1b45235b58054009cc496f6c3ee11d3dc16ed5c388c861761e26a6fce83103a0"
-patched = "193b2dc70dd465d686f35c7b7f74d2cc1b06a55e48cf5c2e4df0f667e03032fc"
+original = "4b7e5675f834ac56bf3459628adfe1425c2346a1c224ee6ea0a3be9f996db254"
+patched = "4a7ca99808b4e49a2dc77a620d4fb7d8219b974ab5b3d5b5709084942805dc9a"
 
 [profile.pixel_v2.hashes_seekable]
-original = "52284308fae10cbaf09ade14e92f3bbe6149751a42bff15432982fcef8d890ab"
-patched = "7ad74ac87ddcaf34938017e6149a646041d70926e31ecda93e156e9397467b3b"
+original = "66b44b148b35a8a998214e0ae36470b42ffd6d2974e18cd8fa12cd8af0c98540"
+patched = "5ddec4bb56dd78a49fbc49e9ad3de7710b0b008b031ff4dfce8fdc775e753ad1"


### PR DESCRIPTION
* There is now a stable release of bzip2-rs with the fix for both the C and Rust versions of bzip2 being compiled.

* The zlib-rs deflate implementation is faster than the default miniz_oxide. Changing this requires updating the checksums in the e2e tests due to slight differences in compression levels between the two implementations.

* Temporarily silence RUSTSEC-2025-0007 to avoid blocking CI. The ring library is no longer maintained.