### PR TITLE
cli/ota: Fix incorrect unprotected partition warning with --skip-system-ota-cert

### DIFF
--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -373,8 +373,9 @@ fn get_vbmeta_patch_order(
                     .get_mut(vbmeta_name.as_str())
                     .unwrap()
                     .insert(partition_name.to_owned());
-                missing.remove(partition_name);
             }
+
+            missing.remove(partition_name);
         }
     }
 


### PR DESCRIPTION
The filtering out of partitions was done at the wrong scope, causing avbroot to warn that extracted-but-unmodified partitions were not protected by AVB. We never encountered this before because the system image was always patched and unmodified boot images got filtered out at an earlier phase during patching.