### PR TITLE
cli/ota: Discard unmodified system image temp file earlier

### DIFF
--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -784,8 +784,6 @@ fn patch_ota_payload(
         cancel_signal,
     )?;
 
-    // Main patching operation is done. Unmodified boot images no longer need to
-    // be kept around.
     input_files
         .retain(|n, f| !(f.state == InputFileState::Extracted && RequiredImages::is_boot(n)));
 
@@ -800,6 +798,9 @@ fn patch_ota_payload(
             cancel_signal,
         )?)
     };
+
+    input_files
+        .retain(|n, f| !(f.state == InputFileState::Extracted && RequiredImages::is_system(n)));
 
     let mut vbmeta_headers = load_vbmeta_images(&mut input_files, &vbmeta_images)?;
 


### PR DESCRIPTION
This is the same optimization as is currently done for boot images. There's no reason to keep the temp file around for the entire patching process if it's unmodified and we're not going to be copying its data into the payload.