### PR TITLE
Add support for changing VABC CoW compression algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,18 @@ Verified boot is disabled by vbmeta's header flags: 0x3
 
 To forcibly enable AVB (by clearing the flags), pass in `--clear-vbmeta-flags`.
 
+### Changing virtual A/B CoW compression algorithm
+
+The virtual A/B CoW compression algorithm can be changed by passing in `--vabc-algo <algo>` with `gz` or `lz4`. OTAs normally use an algorithm that is compatible with the initial version of Android shipped on the device.
+
+* Devices launching with Android 12 support `gz` and `brotli` (unsupported by avbroot)
+* Devices launching with Android 14 support `lz4`
+* Devices launching with Android 15 support `zstd` (unsupported by avbroot)
+
+Picking a fast algorithm, like lz4, can speed up OTA installation significantly when installing via a custom OTA updater app. However, there is no performance difference when sideloading an OTA from recovery mode.
+
+Note that the currently running version of Android must support the specified compression algorithm or else the OTA will fail to install. For example, trying to install an Android 14 OTA that uses lz4 CoW compression will fail if the running system is Android 13.
+
 ### Non-interactive use
 
 avbroot prompts for the private key passphrases interactively by default. To run avbroot non-interactively, either:

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -143,7 +143,7 @@ patched = "27b80c7be9c1e527ea26abe3dabde245c580e6f26ec084204278fbfd81a39f83"
 # What's unique: boot (boot v2)
 
 [profile.pixel_v2]
-vabc_algo = "Gzip"
+vabc_algo = "Gz"
 
 [profile.pixel_v2.partitions.boot]
 avb.signed = false


### PR DESCRIPTION
Devices that launch with Android <14 generally use gzip as the CoW compression algorithm. This never changes because future full OTAs always need to be installable from the version of Android the device launched with.

However, for users that don't care about the upgrade path from old versions of Android, a new `--vabc-algo` option can be used to switch from gz to lz4 compression. This can cut down the OTA installation time by more than 2/3rds when installing via a custom OTA updater app. On my Pixel Tablet, the installation time for the update_engine DOWNLOADING phase decreased from 32:05 to 9:41. Note that this has absolutely no effect on the performance when sideloading from recovery mode because that does not use CoW.

When this new option is used, all dynamic partitions need to be extracted from the OTA during patching so that the CoW estimates can be recomputed. This will slow down the patching process and use up more temporary disk space.