### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
@@ -36,9 +36,9 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -51,33 +51,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -95,6 +95,9 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert_matches"
@@ -104,9 +107,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avbroot"
@@ -172,9 +175,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "beef"
@@ -222,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byteorder"
@@ -240,22 +243,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
- "bzip2-sys",
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -312,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -323,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -345,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -355,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -367,30 +359,30 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.52"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a554639e42d0c838336fc4fbedb9e2df3ad1fa4acda149f9126b4ccfcd7900f"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cms"
@@ -406,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -541,7 +533,18 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -597,12 +600,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -631,9 +634,9 @@ checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -683,7 +686,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -723,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -858,30 +861,30 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864a00c8d019e36216b69c2c4ce50b83b7bd966add3cf5ba554ec44f8bebcf5"
+checksum = "775bf80d5878ab7c2b1080b5351a48b2f737d9f6f8b383574eebcc22be0dfccb"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "liblzma"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66352d7a8ac12d4877b6e6ea5a9b7650ee094257dc40889955bea5bc5b08c1d0"
+checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5839bad90c3cc2e0b8c4ed8296b80e86040240f81d46b9c0e9bc8dd51ddd3af1"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
 dependencies = [
  "cc",
  "libc",
@@ -896,9 +899,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
 dependencies = [
  "zlib-rs",
 ]
@@ -937,7 +940,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -951,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
 ]
@@ -966,9 +969,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -998,14 +1001,14 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1144,42 +1147,43 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1245,12 +1249,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1264,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1274,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
  "itertools",
@@ -1288,28 +1292,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.103",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "prost-reflect"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+checksum = "6e6b545c556471033fc1099868fca468bff8cf034f7bb9153b445f24d00aa28d"
 dependencies = [
  "logos",
  "miette",
@@ -1319,18 +1323,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "protox"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424c2bd294b69c49b949f3619362bc3c5d28298cd1163b6d1a62df37c16461aa"
+checksum = "8555716f64c546306ddf3383065dc40d4232609e79e0a4c50e94e87d54f30fb4"
 dependencies = [
  "bytes",
  "miette",
@@ -1343,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "protox-parse"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57927f9dbeeffcce7192404deee6157a640cbb3fe8ac11eabbe571565949ab75"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
 dependencies = [
  "logos",
  "miette",
@@ -1364,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1564,14 +1568,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1624,6 +1628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,9 +1641,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -1650,12 +1660,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1688,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1727,17 +1731,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1758,23 +1761,23 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -1786,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topological-sort"
@@ -1809,20 +1812,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1855,13 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typenum"
@@ -1918,9 +1917,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1953,7 +1952,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1975,7 +1974,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2017,7 +2016,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2026,7 +2025,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2035,14 +2043,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2052,10 +2076,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2064,10 +2100,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2076,10 +2124,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2088,16 +2148,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -2147,22 +2219,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2182,22 +2254,36 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "zip"
-version = "0.6.6"
-source = "git+https://github.com/chenxiaolong/zip?rev=989101f9384b9e94e36e6e9e0f51908fdf98bde6#989101f9384b9e94e36e6e9e0f51908fdf98bde6"
+version = "4.1.0"
+source = "git+https://github.com/chenxiaolong/zip2?rev=59685f4dadbfee8cb3ea74c8fbb402b60d8137e8#59685f4dadbfee8cb3ea74c8fbb402b60d8137e8"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.75"
 base64 = "0.22.1"
 bitflags = { version = "2.4.1", features = ["serde"] }
 bstr = "1.6.2"
-bzip2 = { version = "0.5.1", default-features = false, features = ["libbz2-rs-sys"] }
+bzip2 = "0.6.0"
 cap-std = "3.0.0"
 cap-tempfile = "3.0.0"
 clap = { version = "4.4.1", features = ["derive"] }
@@ -34,9 +34,9 @@ memchr = "2.6.0"
 num-bigint-dig = "0.8.4"
 num-traits = "0.2.16"
 passterm = "2.0.3"
-phf = { version = "0.11.2", features = ["macros"] }
+phf = { version = "0.12.1", features = ["macros"] }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pem"] }
-prost = "0.13.1"
+prost = "0.14.1"
 # We can't upgrade to 0.9.0 until rsa updates its rand_core dependency.
 rand = "0.8.5"
 rayon = "1.7.0"
@@ -60,10 +60,12 @@ x509-cert = { version = "0.2.4", features = ["builder"] }
 zerocopy = { version = "0.8.10", features = ["std"] }
 zerocopy-derive = "0.8.5"
 
-# https://github.com/zip-rs/zip/pull/383
+# https://github.com/zip-rs/zip2/pull/367
+# https://github.com/zip-rs/zip2/pull/368
+# For getting the data offset when writing new zip entries.
 [dependencies.zip]
-git = "https://github.com/chenxiaolong/zip"
-rev = "989101f9384b9e94e36e6e9e0f51908fdf98bde6"
+git = "https://github.com/chenxiaolong/zip2"
+rev = "59685f4dadbfee8cb3ea74c8fbb402b60d8137e8"
 default-features = false
 features = ["deflate"]
 
@@ -73,8 +75,8 @@ rustix = { version = "1.0.3", default-features = false, features = ["process"] }
 
 [build-dependencies]
 constcat = "0.6.0"
-prost-build = "0.13.1"
-protox = "0.8.0"
+prost-build = "0.14.1"
+protox = "0.9.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/avbroot/src/cli/args.rs
+++ b/avbroot/src/cli/args.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
-use tracing::{debug, Level};
+use tracing::{Level, debug};
 use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
 
 use crate::cli::{avb, boot, completion, cpio, fec, hashtree, key, lp, ota, payload, sparse};

--- a/avbroot/src/cli/avb.rs
+++ b/avbroot/src/cli/avb.rs
@@ -10,7 +10,7 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use cap_std::{
     ambient_authority,
     fs::{Dir, OpenOptions},
@@ -19,7 +19,7 @@ use clap::{Args, Parser, Subcommand};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use rsa::RsaPublicKey;
 use serde::{Deserialize, Serialize};
-use tracing::{debug_span, info, warn, Span};
+use tracing::{Span, debug_span, info, warn};
 
 use crate::{
     crypto::{self, PassphraseSource, RsaSigningKey},
@@ -27,7 +27,7 @@ use crate::{
         self, AlgorithmType, AppendedDescriptorMut, AppendedDescriptorRef, Descriptor, Footer,
         HashTreeDescriptor, Header, KernelCmdlineDescriptor,
     },
-    stream::{self, check_cancel, PSeekFile, ReadFixedSizeExt, Reopen, ToWriter},
+    stream::{self, PSeekFile, ReadFixedSizeExt, Reopen, ToWriter, check_cancel},
     util,
 };
 

--- a/avbroot/src/cli/boot.rs
+++ b/avbroot/src/cli/boot.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 
 use crate::{

--- a/avbroot/src/cli/cpio.rs
+++ b/avbroot/src/cli/cpio.rs
@@ -9,7 +9,7 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use bstr::ByteSlice;
 use cap_std::{ambient_authority, fs::Dir};
 use clap::{Parser, Subcommand};

--- a/avbroot/src/cli/lp.rs
+++ b/avbroot/src/cli/lp.rs
@@ -9,7 +9,7 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use cap_std::{ambient_authority, fs::Dir};
 use clap::{CommandFactory, Parser, Subcommand};
 use rayon::iter::{

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -10,7 +10,7 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use cap_std::{ambient_authority, fs::Dir};
 use clap::{Args, Parser, Subcommand};
 use tracing::info;

--- a/avbroot/src/cli/sparse.rs
+++ b/avbroot/src/cli/sparse.rs
@@ -10,10 +10,10 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use crc32fast::Hasher;
-use zerocopy::{little_endian, IntoBytes};
+use zerocopy::{IntoBytes, little_endian};
 
 use crate::{
     format::{

--- a/avbroot/src/crypto.rs
+++ b/avbroot/src/crypto.rs
@@ -21,25 +21,25 @@ use cms::{
 };
 use passterm::PromptError;
 use pkcs8::{
-    pkcs5::{pbes2, scrypt},
     DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey, EncryptedPrivateKeyInfo,
     LineEnding, PrivateKeyInfo,
+    pkcs5::{pbes2, scrypt},
 };
 use rand::RngCore;
 use rsa::{
-    pkcs1v15::SigningKey, traits::PublicKeyParts, Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey,
+    Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey, pkcs1v15::SigningKey, traits::PublicKeyParts,
 };
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha512};
 use thiserror::Error;
 use x509_cert::{
+    Certificate,
     builder::{Builder, CertificateBuilder, Profile},
-    der::{pem::PemLabel, referenced::OwnedToRef, Any, Decode, DecodePem, EncodePem},
+    der::{Any, Decode, DecodePem, EncodePem, pem::PemLabel, referenced::OwnedToRef},
     serial_number::SerialNumber,
     spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned},
     time::Validity,
-    Certificate,
 };
 
 use crate::util::DebugString;

--- a/avbroot/src/escape.rs
+++ b/avbroot/src/escape.rs
@@ -4,7 +4,7 @@
 use std::{fmt, marker::PhantomData};
 
 use bstr::{ByteSlice, ByteVec};
-use serde::{de::Visitor, Deserializer, Serializer};
+use serde::{Deserializer, Serializer, de::Visitor};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error)]

--- a/avbroot/src/format/avb.rs
+++ b/avbroot/src/format/avb.rs
@@ -14,10 +14,10 @@ use bstr::ByteSlice;
 use num_bigint_dig::{ModInverse, ToBigInt};
 use num_traits::{Pow, ToPrimitive};
 use ring::digest::{Algorithm, Context};
-use rsa::{traits::PublicKeyParts, BigUint, RsaPublicKey};
+use rsa::{BigUint, RsaPublicKey, traits::PublicKeyParts};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zerocopy::{big_endian, FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, big_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{

--- a/avbroot/src/format/bootimage.rs
+++ b/avbroot/src/format/bootimage.rs
@@ -13,7 +13,7 @@ use num_traits::ToPrimitive;
 use ring::digest::Context;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zerocopy::{little_endian, FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, little_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
@@ -669,11 +669,7 @@ impl fmt::Display for BootImageV3Through4 {
 
 impl BootImageExt for BootImageV3Through4 {
     fn header_version(&self) -> u32 {
-        if self.v4_extra.is_some() {
-            4
-        } else {
-            3
-        }
+        if self.v4_extra.is_some() { 4 } else { 3 }
     }
 
     fn header_size(&self) -> u32 {
@@ -1094,11 +1090,7 @@ impl fmt::Display for VendorBootImageV3Through4 {
 
 impl BootImageExt for VendorBootImageV3Through4 {
     fn header_version(&self) -> u32 {
-        if self.v4_extra.is_some() {
-            4
-        } else {
-            3
-        }
+        if self.v4_extra.is_some() { 4 } else { 3 }
     }
 
     fn header_size(&self) -> u32 {

--- a/avbroot/src/format/compression.rs
+++ b/avbroot/src/format/compression.rs
@@ -3,7 +3,7 @@
 
 use std::io::{self, Read, Seek, Write};
 
-use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use liblzma::{
     read::XzDecoder,
     stream::{Check, Stream},

--- a/avbroot/src/format/cpio.rs
+++ b/avbroot/src/format/cpio.rs
@@ -771,11 +771,7 @@ pub fn sort(entries: &mut [CpioEntry]) {
 /// 300000.
 pub fn assign_inodes(entries: &mut [CpioEntry], missing_only: bool) -> Result<()> {
     fn next_non_zero(i: u32) -> u32 {
-        if i == u32::MAX {
-            1
-        } else {
-            i.wrapping_add(1)
-        }
+        if i == u32::MAX { 1 } else { i.wrapping_add(1) }
     }
 
     // (dev maj, dev min) -> (inode set, last assigned inode)

--- a/avbroot/src/format/fec.rs
+++ b/avbroot/src/format/fec.rs
@@ -16,7 +16,7 @@ use rayon::{
     slice::{ParallelSlice, ParallelSliceMut},
 };
 use thiserror::Error;
-use zerocopy::{little_endian, FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, little_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
@@ -827,7 +827,7 @@ impl<W: Write> ToWriter<W> for FecImage {
 mod tests {
     use std::{
         io::{Cursor, Seek},
-        sync::{atomic::AtomicBool, Arc},
+        sync::{Arc, atomic::AtomicBool},
     };
 
     use assert_matches::assert_matches;

--- a/avbroot/src/format/hashtree.rs
+++ b/avbroot/src/format/hashtree.rs
@@ -16,7 +16,7 @@ use rayon::{
 };
 use ring::digest::{Algorithm, Context};
 use thiserror::Error;
-use zerocopy::{little_endian, FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, little_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{

--- a/avbroot/src/format/lp.rs
+++ b/avbroot/src/format/lp.rs
@@ -13,7 +13,7 @@ use bitflags::bitflags;
 use bstr::ByteSlice;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zerocopy::{byteorder::little_endian, FromBytes, FromZeros, Immutable, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, byteorder::little_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
     stream::{
         CountingReader, FromReader, ReadDiscardExt, ReadFixedSizeExt, ToWriter, WriteZerosExt,
     },
-    util::{self, is_zero, DebugString},
+    util::{self, DebugString, is_zero},
 };
 
 /// Magic value for [`RawGeometry::magic`].
@@ -812,7 +812,7 @@ impl RawExtent {
                 return Err(Error::ExtentInvalidType {
                     index,
                     extent_type: n,
-                })
+                });
             }
         }
 

--- a/avbroot/src/format/mod.rs
+++ b/avbroot/src/format/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 pub mod avb;
@@ -13,3 +13,4 @@ pub mod padding;
 pub mod payload;
 pub mod sparse;
 pub mod verityrs;
+pub mod zip;

--- a/avbroot/src/format/payload.rs
+++ b/avbroot/src/format/payload.rs
@@ -11,10 +11,10 @@ use std::{
     sync::atomic::AtomicBool,
 };
 
-use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use bzip2::write::BzDecoder;
-use flate2::{write::GzEncoder, Compression};
+use flate2::{Compression, write::GzEncoder};
 use liblzma::{
     stream::{Check, Stream},
     write::XzDecoder,
@@ -30,14 +30,14 @@ use ring::digest::{Context, Digest};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use x509_cert::Certificate;
-use zerocopy::{big_endian, FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, big_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
     crypto::{self, RsaPublicKeyExt, RsaSigningKey, SignatureAlgorithm},
     protobuf::chromeos_update_engine::{
-        install_operation::Type, signatures::Signature, DeltaArchiveManifest, Extent,
-        InstallOperation, PartitionInfo, PartitionUpdate, Signatures,
+        DeltaArchiveManifest, Extent, InstallOperation, PartitionInfo, PartitionUpdate, Signatures,
+        install_operation::Type, signatures::Signature,
     },
     stream::{
         self, CountingReader, FromReader, HashingWriter, ReadDiscardExt, ReadFixedSizeExt,
@@ -121,7 +121,9 @@ pub enum Error {
     DataWrite(&'static str, #[source] io::Error),
     #[error("Expected {expected} bytes, but only wrote {actual} bytes")]
     UnwrittenData { actual: u64, expected: u64 },
-    #[error("I/O error when applying {op_type:?} operation for {num_blocks} blocks starting at {start_block}")]
+    #[error(
+        "I/O error when applying {op_type:?} operation for {num_blocks} blocks starting at {start_block}"
+    )]
     OperationApply {
         op_type: Type,
         start_block: u64,

--- a/avbroot/src/format/sparse.rs
+++ b/avbroot/src/format/sparse.rs
@@ -11,7 +11,7 @@ use std::{
 use crc32fast::Hasher;
 use dlv_list::{Index, VecList};
 use thiserror::Error;
-use zerocopy::{byteorder::little_endian, FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, byteorder::little_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::stream::ReadDiscardExt;
@@ -225,7 +225,7 @@ impl RawChunk {
                 return Err(Error::InvalidChunkType {
                     index,
                     chunk_type: t,
-                })
+                });
             }
         };
 

--- a/avbroot/src/format/zip.rs
+++ b/avbroot/src/format/zip.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::io::{self, Seek, SeekFrom, Write};
+
+use zip::{
+    ZipWriter,
+    result::ZipResult,
+    write::{FileOptionExtension, FileOptions, StreamWriter},
+};
+
+/// A wrapper around a seekable writer. `W` must implement [`Seek`], but only
+/// during the creation of a new instance. The resulting type can be stored in a
+/// parent container where the generic type does not implement [`Seek`].
+pub struct SeekWriter<W: Write> {
+    inner: W,
+    seek_fn: fn(&mut W, SeekFrom) -> io::Result<u64>,
+}
+
+impl<W: Write> SeekWriter<W> {
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: Write + Seek> SeekWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner,
+            seek_fn: W::seek,
+        }
+    }
+}
+
+impl<W: Write> Write for SeekWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl<W: Write> Seek for SeekWriter<W> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        (self.seek_fn)(&mut self.inner, pos)
+    }
+}
+
+/// This is an ugly hack to have a single type represent both seekable and
+/// streaming [`ZipWriter`]s. `W` only needs to implement [`Seek`] when creating
+/// a seekable instance via [`Self::new_seekable`].
+pub enum ZipWriterWrapper<W: Write> {
+    Streaming(ZipWriter<StreamWriter<W>>),
+    Seekable(ZipWriter<SeekWriter<W>>),
+}
+
+impl<W: Write + Seek> ZipWriterWrapper<W> {
+    pub fn new_seekable(inner: W) -> Self {
+        Self::Seekable(ZipWriter::new(SeekWriter::new(inner)))
+    }
+}
+
+impl<W: Write> ZipWriterWrapper<W> {
+    pub fn new_streaming(inner: W) -> Self {
+        Self::Streaming(ZipWriter::new_stream(inner))
+    }
+
+    pub fn start_file(
+        &mut self,
+        name: impl ToString,
+        options: FileOptions<impl FileOptionExtension>,
+    ) -> ZipResult<u64> {
+        match self {
+            Self::Streaming(z) => z.start_file(name, options),
+            Self::Seekable(z) => z.start_file(name, options),
+        }
+    }
+
+    pub fn finish(self) -> ZipResult<W> {
+        match self {
+            Self::Streaming(z) => Ok(z.finish()?.into_inner()),
+            Self::Seekable(z) => Ok(z.finish()?.into_inner()),
+        }
+    }
+}
+
+impl<W: Write> Write for ZipWriterWrapper<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Streaming(z) => z.write(buf),
+            Self::Seekable(z) => z.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Streaming(z) => z.flush(),
+            Self::Seekable(z) => z.flush(),
+        }
+    }
+}

--- a/avbroot/src/main.rs
+++ b/avbroot/src/main.rs
@@ -4,8 +4,8 @@
 use std::{
     process::ExitCode,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 

--- a/avbroot/src/octal.rs
+++ b/avbroot/src/octal.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use num_traits::{Num, PrimInt};
-use serde::{de::Visitor, Deserializer, Serializer};
+use serde::{Deserializer, Serializer, de::Visitor};
 
 pub fn serialize<S, T>(data: &T, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -24,9 +24,9 @@ use regex::bytes::Regex;
 use ring::digest::Context;
 use rsa::RsaPublicKey;
 use thiserror::Error;
-use tracing::{debug, debug_span, trace, warn, Span};
+use tracing::{Span, debug, debug_span, trace, warn};
 use x509_cert::Certificate;
-use zip::{result::ZipError, ZipArchive};
+use zip::{ZipArchive, result::ZipError};
 
 use crate::{
     crypto::{self, RsaSigningKey},

--- a/avbroot/src/patch/otacert.rs
+++ b/avbroot/src/patch/otacert.rs
@@ -6,8 +6,8 @@ use std::{borrow::Cow, cmp::Ordering, io::Cursor, path::Path};
 use bitflags::bitflags;
 use thiserror::Error;
 use tracing::trace;
-use x509_cert::{der::asn1::BitString, Certificate};
-use zip::{result::ZipError, write::FileOptions, CompressionMethod, ZipWriter};
+use x509_cert::{Certificate, der::asn1::BitString};
+use zip::{CompressionMethod, DateTime, ZipWriter, result::ZipError, write::SimpleFileOptions};
 
 use crate::{crypto, format::ota};
 
@@ -79,7 +79,9 @@ pub fn create_zip(cert: &Certificate, flags: OtaCertBuildFlags) -> Result<Vec<u8
         CompressionMethod::Stored
     };
 
-    let options = FileOptions::default().compression_method(compression_method);
+    let options = SimpleFileOptions::default()
+        .last_modified_time(DateTime::default())
+        .compression_method(compression_method);
     let name = "ota.x509.pem";
     writer.start_file(name, options).map_err(Error::ZipWrite)?;
 

--- a/avbroot/src/patch/system.rs
+++ b/avbroot/src/patch/system.rs
@@ -10,7 +10,7 @@ use std::{
 use memchr::memmem;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use thiserror::Error;
-use tracing::{debug, debug_span, trace, Span};
+use tracing::{Span, debug, debug_span, trace};
 use x509_cert::Certificate;
 use zip::ZipArchive;
 

--- a/avbroot/src/stream.rs
+++ b/avbroot/src/stream.rs
@@ -5,8 +5,8 @@ use std::{
     fs::File,
     io::{self, BufReader, BufWriter, Cursor, Read, Seek, SeekFrom, Write},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex, RwLock,
+        atomic::{AtomicBool, Ordering},
     },
 };
 

--- a/deny.toml
+++ b/deny.toml
@@ -69,5 +69,5 @@ bypass = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
-    "https://github.com/chenxiaolong/zip",
+    "https://github.com/chenxiaolong/zip2",
 ]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -24,10 +24,12 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 x509-cert = "0.2.5"
 
-# https://github.com/zip-rs/zip/pull/383
+# https://github.com/zip-rs/zip2/pull/367
+# https://github.com/zip-rs/zip2/pull/368
+# For getting the data offset when writing new zip entries.
 [dependencies.zip]
-git = "https://github.com/chenxiaolong/zip"
-rev = "989101f9384b9e94e36e6e9e0f51908fdf98bde6"
+git = "https://github.com/chenxiaolong/zip2"
+rev = "59685f4dadbfee8cb3ea74c8fbb402b60d8137e8"
 default-features = false
 
 [features]

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -51,12 +51,12 @@ data.version = "vendor_v4"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v4_gki.hashes_streaming]
-original = "55310b8b2fc95ed1ea0df3d4e742afb690f6cafeb8b528cd222e398f9a3b8d1a"
-patched = "f666bf02a18f8395827502fa998b925387e204e776c93c01e786f286bdaafdd5"
+original = "ef6261cd9ebea90f036e52a46160a400c5b8f6ef24ed2469c4a1e9689987aa06"
+patched = "37fd353a766a7b9a339fbf51fa79c703e94640dc6a2c6310d79357aaefcc7ca1"
 
 [profile.pixel_v4_gki.hashes_seekable]
-original = "b281face363cd0a0c82cef164e94c762b322a5eff715f00c9cd6a2dc74728acc"
-patched = "8c98b5b296a84098beb5ef64a5afb166ab1ba99a0eb79a6dc2f273b505922c22"
+original = "8a2c717607c10dfa5483d6f9a9f37b3d978acaf8d2ea18e36544af267943e750"
+patched = "2c4734c9e1d028ee6aaf02bb416e5e173857faffd2ca067366790655147b3afa"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -93,12 +93,12 @@ data.version = "vendor_v4"
 data.ramdisks = [["init", "otacerts", "first_stage", "dsu_key_dir"], ["dlkm"]]
 
 [profile.pixel_v4_non_gki.hashes_streaming]
-original = "c3762b138056b053632a10bd8da8dc40aa0b639200d0dba8d7184a88d54212d1"
-patched = "fd9921db535c9a8bfaa218b5aabb465b0f0f8c81e45df6d9a5fb66d859f04028"
+original = "630220ef813a2b4743d1941179cc9705da86ad4805f1c52341dcb38fbce3d29e"
+patched = "b725e91751fe58aed20495aecbf9b4bdc14d2799cd88dcbd58f3a3b02b3af15b"
 
 [profile.pixel_v4_non_gki.hashes_seekable]
-original = "522e6de6eb90712dfa371302dd9358fa3ed67ea1683220c767f668f31362b0b0"
-patched = "e722443735bd658a9c482a7a40a57712de25517e5298dd5beeb9d5cce9be0b30"
+original = "1afbe6867ded345d941098ee7c7fcf94a3df52c50ff96ab8f3a67b2ab957259a"
+patched = "4357b977249006b101002c961916f962787315a80b8608494c6a1f0cf09cecd1"
 
 # Google Pixel 4a 5G
 # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -136,12 +136,12 @@ data.version = "vendor_v3"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v3.hashes_streaming]
-original = "154e20d00c73b15ffa7d350262d8124a0476d1643742c57a748029609c2a6a2a"
-patched = "1aff6ceb3b07507b4d3d39d495d975b65498344f1a8d24434593ec284095c475"
+original = "9b65037343d45211e0f9706929cba34643a9c54274d1b39740c43f45974984e0"
+patched = "fb23ab9616968b38b96d1e5e6a503154f89aebc1741e89a9e9dfd2c4d9946b05"
 
 [profile.pixel_v3.hashes_seekable]
-original = "fb37620bec9e5e104f86ed398f7e08f6c2187173665eb336e4c7ae58e8b50b0e"
-patched = "c85e4b9491b53c9e4cbdfb40ef06d5377fbe2b3587d5372b1e20159e65da31df"
+original = "e581934887dd93b8a9d9c3aa5dec1d48aa7e01bf01ac507e8c5fb256b59cbe7d"
+patched = "669a826abc6d67e7e0b1def724aa7b470461087255c65663d195df1426a355f0"
 
 # Google Pixel 4a
 # What's unique: boot (boot v2)
@@ -169,9 +169,9 @@ data.type = "vbmeta"
 data.deps = ["system"]
 
 [profile.pixel_v2.hashes_streaming]
-original = "3715823384e592f76e76f7177a11aec80b9fcb574d049d44efa2d7064c1f51aa"
-patched = "b87d9d979beaae57bde2ad21cca612c7330549cfb62661d87a62d30c3ca6e0ba"
+original = "f10ee15c900a474cc6bbefa705f272cef42636ea096e75563d2d78f6c4327fd1"
+patched = "6929f65909037f5550a53982b71e96bdf69ab876bc5e86702c469ed601be8a9a"
 
 [profile.pixel_v2.hashes_seekable]
-original = "5bd47981d15e5795d27f63eb083b5b0dc9c84542a4388cbfcb7f850e26c69f9f"
-patched = "67d36e758366386038fb8440aceb689c317d59a565648020faa633734a7cda2e"
+original = "4e863d251b9ff6eaa1511f9c03e9bdb8919650b2e0eaf23e33892a639edafcaf"
+patched = "9a103222e73df70a097281525546d25c850df2ae7a2ba715aa5dfbbba3f7972b"

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -9,7 +9,7 @@ use std::{
     path::Path,
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use regex::Regex;
 
 use crate::WORKSPACE_DIR;

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -7,9 +7,9 @@ use std::{
     path::Path,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
-use toml_edit::{value, DocumentMut};
+use toml_edit::{DocumentMut, value};
 
 use crate::WORKSPACE_DIR;
 


### PR DESCRIPTION
The zip crate gained support for streaming writes in its master branch, so we can finally upgrade from our ancient fork of it. The new implementation is done a bit differently, with seekable writers having the `ZipWriter<W>` type and streaming writers having the `ZipWriter<StreamWriter<W>>` type. This forces us to add a new wrapper type since we have to switch between them at runtime.

We still need to maintain a (hopefully temporary) fork of the crate due to a few issues:

1. There's no way to get the original underlying writer instance back after finalizing a streaming zip. A fix for this has been submitted upstream: https://github.com/zip-rs/zip2/pull/367

2. The streaming writes implementation does not include the magic signature for data descriptors. While the zip spec says the magic value is optional and parsers should not require it, older versions of Android's libziparchive do. A fix for this has been submitted upstream: https://github.com/zip-rs/zip2/pull/368

3. There is currently no way to get the data offset of zip entries. avbroot requires this to fill in the OTA metadata's "property files" entries, which Android uses to read file data without parsing the zip file structures.

This new zip update produces files that are slightly different to before. The "version made by" and "version needed to extract" fields are now set to their minimum possible values. Previously, the zip crate was hardcoded to use versions 4.6 and 2.0, respectively.