### PR TITLE
format/ota: Make property files verification more lenient

### DIFF
--- a/avbroot/src/util.rs
+++ b/avbroot/src/util.rs
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
     cmp::Ordering,
-    fmt, mem,
+    fmt::{self, Display},
+    mem,
     ops::{
         Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
     },
@@ -376,6 +377,28 @@ where
             }
         })
         .is_ok()
+}
+
+pub fn join(into_iter: impl IntoIterator<Item = impl Display>, sep: &str) -> String {
+    use std::fmt::Write;
+
+    let mut result = String::new();
+
+    for (i, item) in into_iter.into_iter().enumerate() {
+        if i > 0 {
+            result.push_str(sep);
+        }
+
+        write!(result, "{item}").expect("Failed to allocate");
+    }
+
+    result
+}
+
+pub fn sort<T: Ord>(iter: impl Iterator<Item = T>) -> Vec<T> {
+    let mut items = iter.collect::<Vec<_>>();
+    items.sort();
+    items
 }
 
 #[cfg(test)]

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -797,7 +797,7 @@ fn create_ota(
         let size = writer.stream_position()?;
 
         entries.push(ZipEntry {
-            name: path.to_owned(),
+            path: path.to_owned(),
             offset,
             size,
         });


### PR DESCRIPTION
Previously, we computed the expected property files string (based on AOSP's rules) and checked if the string in the OTA metadata was a byte-for-byte match. This would fail for OTAs with strings that differ from how AOSP generates them. This could be additional files or just different ordering of the entries.

This commit changes the approach to just verify that the property file entries is a valid subset of the zip file entries. We no longer try to compute the expected value.

This does not change what avbroot generates when patching an OTA. Newly generated property files strings always follow AOSP's rules.

Fixes: #469