### PR TITLE
Allow using SHA-1 as AVB hash algorithm

### DIFF
--- a/README.extra.md
+++ b/README.extra.md
@@ -30,8 +30,6 @@ This subcommand packs a new AVB image from the `avb.toml` file and, for appended
 * To force an image to be signed, use `--key <path> --force`.
 * To force an image to be unsigned, use `--force` without specifying `--key`.
 
-Note that if the image is an appended image and its hash or hash tree descriptor uses an insecure algorithm, like `sha1`, then it will automatically be promoted to `sha256`.
-
 By default, for appended vbmeta images, the output image size will match the size of the original image that was unpacked. This size is specified by the `image_size` field in `avb.toml`. If the image is resizable (eg. `system`), then passing in `--recompute-size` will cause the `image_size` field to be ignored and the smallest possible output file that fits the raw image and AVB metadata will be built. This avoids wasting space if `raw.img` shrunk or allows the packing to work at all if `raw.img` grew. **Do not use this option for non-resizable images** (eg. `boot`) or else the device won't be able to boot.
 
 When packing an image, several of the fields in `avb.toml` may potentially be recomputed. To write a TOML file containing the new values, use `--output-info <output TOML>`. It is safe to overwrite the existing `avb.toml` if desired.

--- a/avbroot/src/format/avb.rs
+++ b/avbroot/src/format/avb.rs
@@ -163,9 +163,9 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-pub(crate) fn digest_algorithm(name: &str, for_verify: bool) -> Result<&'static Algorithm> {
+pub(crate) fn digest_algorithm(name: &str) -> Result<&'static Algorithm> {
     match name {
-        "sha1" if for_verify => Ok(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY),
+        "sha1" => Ok(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY),
         "sha256" => Ok(&ring::digest::SHA256),
         "sha512" => Ok(&ring::digest::SHA512),
         a => Err(Error::UnsupportedHashAlgorithm(a.to_owned())),
@@ -534,7 +534,7 @@ impl HashTreeDescriptor {
         ranges: Option<&[Range<u64>]>,
         cancel_signal: &AtomicBool,
     ) -> Result<()> {
-        let algorithm = digest_algorithm(&self.hash_algorithm, false)?;
+        let algorithm = digest_algorithm(&self.hash_algorithm)?;
         let hash_tree = HashTree::new(self.data_block_size, algorithm, &self.salt);
         let (root_digest, hash_tree_data) = match ranges {
             Some(r) => {
@@ -642,7 +642,7 @@ impl HashTreeDescriptor {
     ) -> Result<()> {
         self.check_offsets()?;
 
-        let algorithm = digest_algorithm(&self.hash_algorithm, true)?;
+        let algorithm = digest_algorithm(&self.hash_algorithm)?;
 
         util::check_bounds(self.tree_size, ..=HASH_TREE_MAX_SIZE)
             .map_err(|e| Error::IntOutOfBounds("HashTree::tree_size", e))?;
@@ -903,10 +903,9 @@ impl HashDescriptor {
     fn calculate(
         &self,
         reader: impl Read,
-        for_verify: bool,
         cancel_signal: &AtomicBool,
     ) -> Result<ring::digest::Digest> {
-        let algorithm = digest_algorithm(&self.hash_algorithm, for_verify)?;
+        let algorithm = digest_algorithm(&self.hash_algorithm)?;
         let mut context = Context::new(algorithm);
         context.update(&self.salt);
 
@@ -924,14 +923,14 @@ impl HashDescriptor {
 
     /// Update the root hash from the input reader's contents.
     pub fn update(&mut self, reader: impl Read, cancel_signal: &AtomicBool) -> Result<()> {
-        let digest = self.calculate(reader, false, cancel_signal)?;
+        let digest = self.calculate(reader, cancel_signal)?;
         self.root_digest = digest.as_ref().to_vec();
         Ok(())
     }
 
     /// Verify the root hash against the input reader.
     pub fn verify(&self, reader: impl Read, cancel_signal: &AtomicBool) -> Result<()> {
-        let digest = self.calculate(reader, true, cancel_signal)?;
+        let digest = self.calculate(reader, cancel_signal)?;
 
         if self.root_digest != digest.as_ref() {
             return Err(Error::InvalidRootDigest {

--- a/avbroot/src/format/hashtree.rs
+++ b/avbroot/src/format/hashtree.rs
@@ -493,7 +493,7 @@ impl HashTreeImage {
     const VERSION: u16 = 1;
 
     fn digest_algorithm(name: &str) -> Result<&'static Algorithm> {
-        avb::digest_algorithm(name, false)
+        avb::digest_algorithm(name)
             .map_err(|_| Error::UnsupportedHashAlgorithm(name.to_owned().into_bytes()))
     }
 

--- a/avbroot/src/patch/system.rs
+++ b/avbroot/src/patch/system.rs
@@ -190,23 +190,9 @@ pub fn patch_system_image(
         return Err(Error::OldZipNotFound);
     }
 
-    let update_ranges = if descriptor.hash_algorithm == "sha1" {
-        // Promote to a secure algorithm. SHA1 is allowed for verification only.
-        // The entire hash tree and FEC data will need to be recomputed.
-        let new_algorithm = "sha256".to_owned();
-
-        debug!(
-            "Changing insecure hash algorithm {} to {new_algorithm}",
-            descriptor.hash_algorithm,
-        );
-
-        descriptor.hash_algorithm = new_algorithm;
-        None
-    } else {
-        // Only need to update the hash tree and FEC data corresponding to the
-        // modified regions.
-        Some(modified_ranges.as_slice())
-    };
+    // Only need to update the hash tree and FEC data corresponding to the
+    // modified regions.
+    let update_ranges = Some(modified_ranges.as_slice());
 
     descriptor
         .update(input, output, update_ranges, cancel_signal)


### PR DESCRIPTION
Previously, we automatically promoted SHA-1 to SHA-256 because SHA-1 is insecure, but there are devices that don't support SHA-256. It's safer to just keep using the original hash algorithm.