### PR TITLE
cli/ota: Re-sign signed image when header verification fails

### DIFF
--- a/avbroot/src/cli/avb.rs
+++ b/avbroot/src/cli/avb.rs
@@ -331,7 +331,7 @@ fn sign_or_clear(info: &mut AvbInfo, orig_header: &Header, key_group: &KeyGroup)
         } else {
             SignAction::Clear
         }
-    } else if originally_signed && &info.header != orig_header {
+    } else if originally_signed && (&info.header != orig_header || info.header.verify().is_err()) {
         SignAction::Sign
     } else {
         // If the original image was signed, we can preserve the existing


### PR DESCRIPTION
Previously, unless forced, `avbroot avb pack` would only re-sign an image if the packing process changed the header (eg. root digest). However, this isn't sufficient when packing an image after the user modifies avb.toml manually. This is especially the case when packing a vbmeta image, which never triggered the old check because it does not contain a raw image.