### PR TITLE
Switch to rawzip crate for zip file handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,6 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "assert_matches"
@@ -139,6 +136,7 @@ dependencies = [
  "prost-build",
  "protox",
  "rand",
+ "rawzip",
  "rayon",
  "regex",
  "ring",
@@ -157,7 +155,6 @@ dependencies = [
  "x509-cert",
  "zerocopy",
  "zerocopy-derive",
- "zip",
 ]
 
 [[package]]
@@ -235,12 +232,6 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -540,17 +531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +557,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "hex",
+ "rawzip",
  "ring",
  "rsa",
  "serde",
@@ -586,7 +567,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "x509-cert",
- "zip",
 ]
 
 [[package]]
@@ -1372,6 +1352,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawzip"
+version = "0.3.1"
+source = "git+https://github.com/nickbabcock/rawzip?rev=562b92b73df135829b593abd29892ca73fa7b51a#562b92b73df135829b593abd29892ca73fa7b51a"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,12 +1570,6 @@ dependencies = [
  "digest",
  "rand_core",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -2175,32 +2154,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "4.1.0"
-source = "git+https://github.com/chenxiaolong/zip2?rev=59685f4dadbfee8cb3ea74c8fbb402b60d8137e8#59685f4dadbfee8cb3ea74c8fbb402b60d8137e8"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
- "zopfli",
-]
-
-[[package]]
 name = "zlib-rs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
-
-[[package]]
-name = "zopfli"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -58,14 +58,9 @@ x509-cert = { version = "0.2.4", features = ["builder"] }
 zerocopy = { version = "0.8.10", features = ["std"] }
 zerocopy-derive = "0.8.5"
 
-# https://github.com/zip-rs/zip2/pull/367
-# https://github.com/zip-rs/zip2/pull/368
-# For getting the data offset when writing new zip entries.
-[dependencies.zip]
-git = "https://github.com/chenxiaolong/zip2"
-rev = "59685f4dadbfee8cb3ea74c8fbb402b60d8137e8"
-default-features = false
-features = ["deflate"]
+[dependencies.rawzip]
+git = "https://github.com/nickbabcock/rawzip"
+rev = "562b92b73df135829b593abd29892ca73fa7b51a"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.158"

--- a/avbroot/src/format/zip.rs
+++ b/avbroot/src/format/zip.rs
@@ -1,103 +1,517 @@
 // SPDX-FileCopyrightText: 2025 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::io::{self, Seek, SeekFrom, Write};
-
-use zip::{
-    ZipWriter,
-    result::ZipResult,
-    write::{FileOptionExtension, FileOptions, StreamWriter},
+use std::{
+    cmp::Ordering,
+    io::{self, Cursor, Read, Seek, SeekFrom, Write},
 };
 
-/// A wrapper around a seekable writer. `W` must implement [`Seek`], but only
-/// during the creation of a new instance. The resulting type can be stored in a
-/// parent container where the generic type does not implement [`Seek`].
-pub struct SeekWriter<W: Write> {
-    inner: W,
-    seek_fn: fn(&mut W, SeekFrom) -> io::Result<u64>,
+use bstr::ByteSlice;
+use rawzip::{
+    CompressionMethod, RECOMMENDED_BUFFER_SIZE, ReaderAt, ZipArchive, ZipEntries, ZipEntry,
+    ZipFileHeaderRecord, ZipLocator, ZipReader, ZipSliceArchive, ZipSliceEntries, ZipSliceEntry,
+    ZipSliceVerifier, ZipVerifier,
+    extra_fields::{ExtraFieldId, ExtraFields},
+};
+use zerocopy::{FromZeros, IntoBytes, little_endian};
+use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::{
+    format::compression::{self, CompressedFormat, CompressedReader, CompressedWriter},
+    stream::PSeekFile,
+};
+
+pub trait ZipFileHeaderRecordExt<'a> {
+    fn file_path_utf8(&self) -> Result<&'a str, rawzip::Error>;
 }
 
-impl<W: Write> SeekWriter<W> {
-    pub fn into_inner(self) -> W {
-        self.inner
+impl<'a> ZipFileHeaderRecordExt<'a> for ZipFileHeaderRecord<'a> {
+    fn file_path_utf8(&self) -> Result<&'a str, rawzip::Error> {
+        str::from_utf8(self.file_path().as_bytes())
+            .map_err(|e| rawzip::ErrorKind::InvalidUtf8(e).into())
     }
 }
 
-impl<W: Write + Seek> SeekWriter<W> {
-    pub fn new(inner: W) -> Self {
-        Self {
-            inner,
-            seek_fn: W::seek,
+/// Validate that the current entry's compressed data range does not overlap
+/// previously visited entries' ranges. This approach is identical to what
+/// rawzip recommends in their examples.
+fn validate_and_add_range(
+    compressed_ranges: &mut Vec<(u64, u64)>,
+    current_range: (u64, u64),
+    path: &[u8],
+) -> Result<(), rawzip::Error> {
+    let (current_start, current_end) = current_range;
+
+    let insert_pos = compressed_ranges
+        .binary_search_by_key(&current_start, |&(start, _)| start)
+        .unwrap_or_else(|pos| pos);
+
+    if insert_pos > 0 {
+        let (prev_start, prev_end) = compressed_ranges[insert_pos - 1];
+        if prev_end > current_start {
+            return Err(rawzip::ErrorKind::InvalidInput {
+                msg: format!("{:?} ({current_start}..{current_end}) overlaps previous range ({prev_start}..{prev_end})", path.as_bstr()),
+            }.into());
         }
     }
-}
 
-impl<W: Write> Write for SeekWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.write(buf)
+    if insert_pos < compressed_ranges.len() {
+        let (next_start, next_end) = compressed_ranges[insert_pos];
+        if current_end > next_start {
+            return Err(rawzip::ErrorKind::InvalidInput {
+                msg: format!("{:?} ({current_start}..{current_end}) overlaps next range ({next_start}..{next_end})", path.as_bstr()),
+            }.into());
+        }
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
+    compressed_ranges.insert(insert_pos, current_range);
+
+    Ok(())
 }
 
-impl<W: Write> Seek for SeekWriter<W> {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        (self.seek_fn)(&mut self.inner, pos)
-    }
-}
-
-/// This is an ugly hack to have a single type represent both seekable and
-/// streaming [`ZipWriter`]s. `W` only needs to implement [`Seek`] when creating
-/// a seekable instance via [`Self::new_seekable`].
-pub enum ZipWriterWrapper<W: Write> {
-    Streaming(ZipWriter<StreamWriter<W>>),
-    Seekable(ZipWriter<SeekWriter<W>>),
-}
-
-impl<W: Write + Seek> ZipWriterWrapper<W> {
-    pub fn new_seekable(inner: W) -> Self {
-        Self::Seekable(ZipWriter::new(SeekWriter::new(inner)))
-    }
-}
-
-impl<W: Write> ZipWriterWrapper<W> {
-    pub fn new_streaming(inner: W) -> Self {
-        Self::Streaming(ZipWriter::new_stream(inner))
+/// Validate that the entry's compression ratio is not excessively large, based
+/// on a constant factor for [`CompressionMethod::Deflate`]. This approach is
+/// identical to what rawzip recommends in their examples.
+fn validate_compression_ratio(
+    compressed_size: u64,
+    uncompressed_size: u64,
+    path: &[u8],
+) -> Result<(), rawzip::Error> {
+    if compressed_size > 0 && uncompressed_size / compressed_size > 1032 {
+        #[allow(clippy::cast_precision_loss)]
+        return Err(rawzip::ErrorKind::InvalidInput {
+            msg: format!(
+                "{:?} has excessively large compression ratio: {})",
+                path.as_bstr(),
+                uncompressed_size as f64 / compressed_size as f64,
+            ),
+        }
+        .into());
     }
 
-    pub fn start_file(
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct ZipEntriesSafe<'archive, 'buf, R> {
+    archive: &'archive ZipArchive<R>,
+    entries: ZipEntries<'archive, 'buf, R>,
+    compressed_ranges: Vec<(u64, u64)>,
+}
+
+impl<R: ReaderAt> ZipEntriesSafe<'_, '_, R> {
+    #[inline]
+    pub fn next_entry(
         &mut self,
-        name: impl ToString,
-        options: FileOptions<impl FileOptionExtension>,
-    ) -> ZipResult<u64> {
-        match self {
-            Self::Streaming(z) => z.start_file(name, options),
-            Self::Seekable(z) => z.start_file(name, options),
-        }
-    }
+    ) -> Result<Option<(ZipFileHeaderRecord<'_>, ZipEntry<'_, R>)>, rawzip::Error> {
+        let cd_entry = self.entries.next_entry()?;
+        let Some(cd_entry) = cd_entry else {
+            return Ok(None);
+        };
 
-    pub fn finish(self) -> ZipResult<W> {
-        match self {
-            Self::Streaming(z) => Ok(z.finish()?.into_inner()),
-            Self::Seekable(z) => Ok(z.finish()?.into_inner()),
+        validate_compression_ratio(
+            cd_entry.compressed_size_hint(),
+            cd_entry.uncompressed_size_hint(),
+            cd_entry.file_path().as_ref(),
+        )?;
+
+        let entry = self.archive.get_entry(cd_entry.wayfinder())?;
+
+        validate_and_add_range(
+            &mut self.compressed_ranges,
+            entry.compressed_data_range(),
+            cd_entry.file_path().as_ref(),
+        )?;
+
+        Ok(Some((cd_entry, entry)))
+    }
+}
+
+pub trait ZipEntriesSafeExt<R> {
+    fn entries_safe<'archive, 'buf>(
+        &'archive self,
+        buffer: &'buf mut [u8],
+    ) -> ZipEntriesSafe<'archive, 'buf, R>;
+}
+
+impl<R> ZipEntriesSafeExt<R> for ZipArchive<R> {
+    fn entries_safe<'archive, 'buf>(
+        &'archive self,
+        buffer: &'buf mut [u8],
+    ) -> ZipEntriesSafe<'archive, 'buf, R> {
+        let entries = self.entries(buffer);
+
+        ZipEntriesSafe {
+            archive: self,
+            entries,
+            compressed_ranges: Vec::new(),
         }
     }
 }
 
-impl<W: Write> Write for ZipWriterWrapper<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self {
-            Self::Streaming(z) => z.write(buf),
-            Self::Seekable(z) => z.write(buf),
+impl<R, T: ZipEntriesSafeExt<R>> ZipEntriesSafeExt<R> for &T {
+    fn entries_safe<'archive, 'buf>(
+        &'archive self,
+        buffer: &'buf mut [u8],
+    ) -> ZipEntriesSafe<'archive, 'buf, R> {
+        (**self).entries_safe(buffer)
+    }
+}
+
+impl<R, T: ZipEntriesSafeExt<R>> ZipEntriesSafeExt<R> for &mut T {
+    fn entries_safe<'archive, 'buf>(
+        &'archive self,
+        buffer: &'buf mut [u8],
+    ) -> ZipEntriesSafe<'archive, 'buf, R> {
+        (**self).entries_safe(buffer)
+    }
+}
+
+#[derive(Debug)]
+pub struct ZipSliceEntriesSafe<'data, T: AsRef<[u8]>> {
+    archive: &'data ZipSliceArchive<T>,
+    entries: ZipSliceEntries<'data>,
+    compressed_ranges: Vec<(u64, u64)>,
+}
+
+impl<'data, T: AsRef<[u8]>> ZipSliceEntriesSafe<'data, T> {
+    #[inline]
+    pub fn next_entry(
+        &mut self,
+    ) -> Result<Option<(ZipFileHeaderRecord<'data>, ZipSliceEntry<'data>)>, rawzip::Error> {
+        let cd_entry = self.entries.next_entry()?;
+        let Some(cd_entry) = cd_entry else {
+            return Ok(None);
+        };
+
+        validate_compression_ratio(
+            cd_entry.compressed_size_hint(),
+            cd_entry.uncompressed_size_hint(),
+            cd_entry.file_path().as_ref(),
+        )?;
+
+        let entry = self.archive.get_entry(cd_entry.wayfinder())?;
+
+        validate_and_add_range(
+            &mut self.compressed_ranges,
+            entry.compressed_data_range(),
+            cd_entry.file_path().as_ref(),
+        )?;
+
+        Ok(Some((cd_entry, entry)))
+    }
+}
+
+pub trait ZipSliceEntriesSafeExt<T: AsRef<[u8]>> {
+    fn entries_safe(&self) -> ZipSliceEntriesSafe<'_, T>;
+}
+
+impl<T: AsRef<[u8]>> ZipSliceEntriesSafeExt<T> for ZipSliceArchive<T> {
+    fn entries_safe(&self) -> ZipSliceEntriesSafe<'_, T> {
+        let entries = self.entries();
+
+        ZipSliceEntriesSafe {
+            archive: self,
+            entries,
+            compressed_ranges: Vec::new(),
         }
+    }
+}
+
+impl<T: AsRef<[u8]>, U: ZipSliceEntriesSafeExt<T>> ZipSliceEntriesSafeExt<T> for &U {
+    fn entries_safe(&self) -> ZipSliceEntriesSafe<'_, T> {
+        (**self).entries_safe()
+    }
+}
+
+impl<T: AsRef<[u8]>, U: ZipSliceEntriesSafeExt<T>> ZipSliceEntriesSafeExt<T> for &mut U {
+    fn entries_safe(&self) -> ZipSliceEntriesSafe<'_, T> {
+        (**self).entries_safe()
+    }
+}
+
+fn compression_method_to_format(
+    compression_method: CompressionMethod,
+) -> Result<CompressedFormat, rawzip::Error> {
+    match compression_method {
+        CompressionMethod::Store => Ok(CompressedFormat::None),
+        CompressionMethod::Deflate => Ok(CompressedFormat::Deflate),
+        c => Err(rawzip::ErrorKind::InvalidInput {
+            msg: format!("Unsupported compression method: {c:?}"),
+        }
+        .into()),
+    }
+}
+
+pub fn compressed_reader<'archive, R: ReaderAt>(
+    entry: &ZipEntry<'archive, R>,
+    compression_method: CompressionMethod,
+) -> Result<CompressedReader<'archive, ZipReader<&'archive R>>, rawzip::Error> {
+    let format = compression_method_to_format(compression_method)?;
+
+    Ok(CompressedReader::with_format(entry.reader(), format))
+}
+
+pub fn compressed_slice_reader<'archive>(
+    entry: &ZipSliceEntry<'archive>,
+    compression_method: CompressionMethod,
+) -> Result<CompressedReader<'archive, Cursor<&'archive [u8]>>, rawzip::Error> {
+    let format = compression_method_to_format(compression_method)?;
+    let raw_reader = Cursor::new(entry.data());
+
+    Ok(CompressedReader::with_format(raw_reader, format))
+}
+
+pub fn verifying_reader<'archive, R: ReaderAt>(
+    entry: &ZipEntry<'archive, R>,
+    compression_method: CompressionMethod,
+) -> Result<
+    ZipVerifier<'archive, CompressedReader<'archive, ZipReader<&'archive R>>, R>,
+    rawzip::Error,
+> {
+    compressed_reader(entry, compression_method).map(|r| entry.verifying_reader(r))
+}
+
+pub fn verifying_slice_reader<'archive>(
+    entry: &ZipSliceEntry<'archive>,
+    compression_method: CompressionMethod,
+) -> Result<ZipSliceVerifier<CompressedReader<'archive, Cursor<&'archive [u8]>>>, rawzip::Error> {
+    compressed_slice_reader(entry, compression_method).map(|r| entry.verifying_reader(r))
+}
+
+pub fn compressed_writer<'writer, W: Write + 'writer>(
+    writer: W,
+    compression_method: CompressionMethod,
+) -> Result<CompressedWriter<'writer, W>, rawzip::Error> {
+    use compression::Error;
+
+    let format = compression_method_to_format(compression_method)?;
+
+    match CompressedWriter::new(writer, format) {
+        Ok(w) => Ok(w),
+        Err(Error::Lz4Init(e) | Error::XzInit(e)) => Err(e.into()),
+        Err(Error::UnknownFormat | Error::AutoDetect(_)) => unreachable!(),
+    }
+}
+
+pub trait ZipArchivePSeekExt {
+    fn from_pseekfile(
+        mut file: PSeekFile,
+        buffer: &mut [u8],
+    ) -> Result<ZipArchive<PSeekFile>, rawzip::Error> {
+        let end_offset = file.seek(SeekFrom::End(0))?;
+
+        ZipLocator::new()
+            .locate_in_reader(file, buffer, end_offset)
+            .map_err(|(_, e)| e)
+    }
+}
+
+impl ZipArchivePSeekExt for ZipArchive<()> {}
+
+impl ReaderAt for PSeekFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        Self::read_at(self, buf, offset)
+    }
+}
+
+#[derive(Clone, Copy, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C, packed)]
+struct ZipLocalHeader {
+    signature: little_endian::U32,
+    version_needed: little_endian::U16,
+    flags: little_endian::U16,
+    compression_method: little_endian::U16,
+    last_mod_time: little_endian::U16,
+    last_mod_date: little_endian::U16,
+    crc32: little_endian::U32,
+    compressed_size: little_endian::U32,
+    uncompressed_size: little_endian::U32,
+    file_name_len: little_endian::U16,
+    extra_field_len: little_endian::U16,
+}
+
+#[derive(Clone, Copy, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C, packed)]
+struct ZipCentralHeader {
+    pub signature: little_endian::U32,
+    pub version_made_by: little_endian::U16,
+    pub version_needed: little_endian::U16,
+    pub flags: little_endian::U16,
+    pub compression_method: little_endian::U16,
+    pub last_mod_time: little_endian::U16,
+    pub last_mod_date: little_endian::U16,
+    pub crc32: little_endian::U32,
+    pub compressed_size: little_endian::U32,
+    pub uncompressed_size: little_endian::U32,
+    pub file_name_len: little_endian::U16,
+    pub extra_field_len: little_endian::U16,
+    pub file_comment_len: little_endian::U16,
+    pub disk_number_start: little_endian::U16,
+    pub internal_file_attrs: little_endian::U16,
+    pub external_file_attrs: little_endian::U32,
+    pub local_header_offset: little_endian::U32,
+}
+
+/// Convert a streaming zip into a non-streaming one. If any entry uses ZIP64,
+/// the local header must contain an [`ExtraFieldId::ANDROID_ZIP_ALIGNMENT`]
+/// extra field with sufficient size (16 bytes to be safe). This is used as
+/// reserved space for creating a new [`ExtraFieldId::ZIP64`] extra field. Any
+/// leftover space must be at least 4 bytes so that a new extra field can
+/// consume the space. The existing data descriptor will remain in the gap
+/// between entries and data will not be shifted.
+pub fn make_non_streaming(file: impl Read + Write + Seek) -> Result<(), rawzip::Error> {
+    // rawzip currently does not expose the CRC32 value, so we'll have to read
+    // it ourselves.
+    struct EntryInfo {
+        local_header_offset: u64,
+        central_header_offset: u64,
+        crc32: u32,
+        compressed_size: u64,
+        uncompressed_size: u64,
+        local_extra_fields: Vec<u8>,
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        match self {
-            Self::Streaming(z) => z.flush(),
-            Self::Seekable(z) => z.flush(),
-        }
+    let mut to_update = vec![];
+
+    let mut central_buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let mut local_buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = ZipArchive::from_seekable(file, &mut central_buffer)?;
+    let mut entries = archive.entries_safe(&mut central_buffer);
+
+    while let Some((cd_entry, entry)) = entries.next_entry()? {
+        let wf = cd_entry.wayfinder();
+
+        let local_header = entry.local_header(&mut local_buffer)?;
+
+        to_update.push(EntryInfo {
+            local_header_offset: cd_entry.local_header_offset(),
+            central_header_offset: cd_entry.central_directory_offset(),
+            crc32: cd_entry.crc32(),
+            compressed_size: wf.compressed_size_hint(),
+            uncompressed_size: wf.uncompressed_size_hint(),
+            local_extra_fields: local_header.extra_fields().remaining_bytes().to_vec(),
+        });
     }
+
+    let mut file = archive.into_inner().into_inner();
+
+    for entry in to_update {
+        // Clear the central header's streaming flag.
+        let mut central_flags = little_endian::U16::new(0);
+        file.seek(SeekFrom::Start(entry.central_header_offset + 8))?;
+        file.read_exact(central_flags.as_mut_bytes())?;
+        central_flags &= !0x8;
+        file.seek_relative(-(central_flags.as_bytes().len() as i64))?;
+        file.write_all(central_flags.as_bytes())?;
+
+        file.seek(SeekFrom::Start(entry.local_header_offset))?;
+
+        let mut local_header = ZipLocalHeader::new_zeroed();
+        file.read_exact(local_header.as_mut_bytes())?;
+
+        // Clear the local header's streaming flag.
+        local_header.flags &= !0x8;
+
+        // Remove dependency on the data descriptor.
+        local_header.crc32.set(entry.crc32);
+
+        let compressed_is_zip64 = entry.compressed_size >= 0xffffffff;
+        let uncompressed_is_zip64 = entry.uncompressed_size >= 0xffffffff;
+
+        if compressed_is_zip64 {
+            local_header.compressed_size.set(0xffffffff);
+        } else {
+            local_header
+                .compressed_size
+                .set(entry.compressed_size as u32);
+        }
+
+        if uncompressed_is_zip64 {
+            local_header.uncompressed_size.set(0xffffffff);
+        } else {
+            local_header
+                .uncompressed_size
+                .set(entry.uncompressed_size as u32);
+        }
+
+        file.seek_relative(-(local_header.as_bytes().len() as i64))?;
+        file.write_all(local_header.as_bytes())?;
+
+        file.seek_relative(i64::from(local_header.file_name_len.get()))?;
+
+        if !compressed_is_zip64 && !uncompressed_is_zip64 {
+            continue;
+        }
+
+        let mut extra_fields = Vec::with_capacity(entry.local_extra_fields.len());
+        let mut patched_placeholder = false;
+
+        for (id, data) in ExtraFields::new(&entry.local_extra_fields) {
+            if id == ExtraFieldId::ANDROID_ZIP_ALIGNMENT {
+                let zip64_len =
+                    8 * (usize::from(compressed_is_zip64) + usize::from(uncompressed_is_zip64));
+
+                // Any unused space needs to be at least 4 bytes, so we can
+                // properly write a new extra field for padding.
+                let have_needed_space = match data.len().cmp(&zip64_len) {
+                    Ordering::Less => false,
+                    Ordering::Equal => true,
+                    Ordering::Greater => data.len() - zip64_len >= 4,
+                };
+                if !have_needed_space {
+                    return Err(rawzip::ErrorKind::InvalidInput {
+                        msg: format!(
+                            "Invalid reserved ZIP64 local extra field size: {}",
+                            data.len()
+                        ),
+                    }
+                    .into());
+                }
+
+                // The order is indeed backwards compared to the header
+                // fields (APPNOTE 4.5.3).
+                extra_fields.extend_from_slice(&ExtraFieldId::ZIP64.as_u16().to_le_bytes());
+                extra_fields.extend_from_slice(&(zip64_len as u16).to_le_bytes());
+                if uncompressed_is_zip64 {
+                    extra_fields.extend_from_slice(&entry.uncompressed_size.to_le_bytes());
+                }
+                if compressed_is_zip64 {
+                    extra_fields.extend_from_slice(&entry.compressed_size.to_le_bytes());
+                }
+
+                // Keep using ANDROID_ZIP_ALIGNMENT for padding.
+                if data.len() > zip64_len {
+                    let padding_len = data.len() - zip64_len - 4;
+                    extra_fields.extend_from_slice(&id.as_u16().to_le_bytes());
+                    extra_fields.extend_from_slice(&(padding_len as u16).to_le_bytes());
+                    extra_fields.resize(extra_fields.len() + padding_len, 0);
+                }
+
+                patched_placeholder = true;
+            } else if id == ExtraFieldId::ZIP64 {
+                return Err(rawzip::ErrorKind::InvalidInput {
+                    msg: "Unexpected ZIP64 extra field present".to_owned(),
+                }
+                .into());
+            } else {
+                extra_fields.extend_from_slice(&id.as_u16().to_le_bytes());
+                extra_fields.extend_from_slice(&(data.len() as u16).to_le_bytes());
+                extra_fields.extend_from_slice(data);
+            }
+        }
+
+        assert_eq!(extra_fields.len(), entry.local_extra_fields.len());
+
+        if !patched_placeholder {
+            return Err(rawzip::ErrorKind::InvalidInput {
+                msg: "ZIP64 required, but no placeholder extra field found".to_owned(),
+            }
+            .into());
+        }
+
+        file.write_all(&extra_fields)?;
+    }
+
+    Ok(())
 }

--- a/avbroot/src/stream.rs
+++ b/avbroot/src/stream.rs
@@ -395,30 +395,30 @@ impl PSeekFile {
 
     /// Read data from offset. The kernel's file position *will* be changed.
     #[cfg(windows)]
-    fn read_at(&self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         use std::os::windows::fs::FileExt;
-        self.file.read().unwrap().seek_read(buf, self.offset)
+        self.file.read().unwrap().seek_read(buf, offset)
     }
 
     /// Read data from offset. The kernel's file position will *not* be changed.
     #[cfg(unix)]
-    fn read_at(&self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         use std::os::unix::fs::FileExt;
-        self.file.read().unwrap().read_at(buf, self.offset)
+        self.file.read().unwrap().read_at(buf, offset)
     }
 
     /// Write data to offset. The kernel's file position *will* be changed.
     #[cfg(windows)]
-    fn write_at(&self, buf: &[u8]) -> io::Result<usize> {
+    pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         use std::os::windows::fs::FileExt;
-        self.file.read().unwrap().seek_write(buf, self.offset)
+        self.file.read().unwrap().seek_write(buf, offset)
     }
 
     /// Write data to offset. The kernel's file position will *not* be changed.
     #[cfg(unix)]
-    fn write_at(&self, buf: &[u8]) -> io::Result<usize> {
+    pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         use std::os::unix::fs::FileExt;
-        self.file.read().unwrap().write_at(buf, self.offset)
+        self.file.read().unwrap().write_at(buf, offset)
     }
 }
 
@@ -433,7 +433,7 @@ impl Reopen for PSeekFile {
 
 impl Read for PSeekFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = self.read_at(buf)?;
+        let n = self.read_at(buf, self.offset)?;
         self.offset += n as u64;
         Ok(n)
     }
@@ -441,7 +441,7 @@ impl Read for PSeekFile {
 
 impl Write for PSeekFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let n = self.write_at(buf)?;
+        let n = self.write_at(buf, self.offset)?;
         self.offset += n as u64;
         Ok(n)
     }

--- a/deny.toml
+++ b/deny.toml
@@ -73,4 +73,5 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/chenxiaolong/system-properties",
     "https://github.com/chenxiaolong/zip2",
+    "https://github.com/nickbabcock/rawzip",
 ]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -24,13 +24,9 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 x509-cert = "0.2.5"
 
-# https://github.com/zip-rs/zip2/pull/367
-# https://github.com/zip-rs/zip2/pull/368
-# For getting the data offset when writing new zip entries.
-[dependencies.zip]
-git = "https://github.com/chenxiaolong/zip2"
-rev = "59685f4dadbfee8cb3ea74c8fbb402b60d8137e8"
-default-features = false
+[dependencies.rawzip]
+git = "https://github.com/nickbabcock/rawzip"
+rev = "562b92b73df135829b593abd29892ca73fa7b51a"
 
 [lints]
 workspace = true

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -51,12 +51,12 @@ data.version = "vendor_v4"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v4_gki.hashes_streaming]
-original = "4e283ad1e3450795a32f46445bf626f6af983f52bd0a3484b49f8740c1029653"
-patched = "837861bf64e9387380e02d740b21c94e60c41bba4161d85ab44fc5ce86f19631"
+original = "3638d2e253e0647c4aa2d26301522d0c4b98d4c190115f04741066e2c8f25d7c"
+patched = "be9a67884bdae4d04040e8b525cdf6f9c3d2d4ee816154843219192cc2671479"
 
 [profile.pixel_v4_gki.hashes_seekable]
-original = "0ab2403a2634f00063c44f9a477a672205922ede189442e18850dd8efceb5d6f"
-patched = "2d94841c3be6cc1739f4c7ad5d9db048301b3f93f8ccd510e2c825bf13ecff90"
+original = "acbc1e5af57390b10d5f7fe3770e47b4db0c7200f9e1d63036fdb8c53c60e3e5"
+patched = "6e4bb1967045238cf02a61d422c2d9e4b40f21cb0d19e2ea548091d49808b7a9"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -93,12 +93,12 @@ data.version = "vendor_v4"
 data.ramdisks = [["init", "otacerts", "first_stage", "dsu_key_dir"], ["dlkm"]]
 
 [profile.pixel_v4_non_gki.hashes_streaming]
-original = "c3a978b7225632875d3b1e87e852494b1a69019f5ba4099cf3981503623facca"
-patched = "cf0ef7429c4657875018d10d7302aaca371b21c5968af234aabd941304f0035b"
+original = "1785927b7768675ea7d261cf44f659b7402cf1799b636fd9f55b420f6e04b40d"
+patched = "62d1fd1ff5f37d140cfaa3ca584a457144724e5ca3cff2c23c233f0a87037a74"
 
 [profile.pixel_v4_non_gki.hashes_seekable]
-original = "cc11ee5a5be66bf34dcb6834a9a635016fa9f82dd0d9a2fb1029aa4f218d1d2e"
-patched = "e2fb7d3ce2c697372fb342ae5cd7bb606cd764f06a2aa8a2d6d7bd2c88456780"
+original = "46de37c516db66b254629ff21a0addf5524fe33c253b4c0dfc0a93d6405d7093"
+patched = "45f2341c7d5aa31a412418672067ffe95f451f132cb16f049c257099727cef77"
 
 # Google Pixel 4a 5G
 # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -136,12 +136,12 @@ data.version = "vendor_v3"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v3.hashes_streaming]
-original = "d12d92c051bcc832cc9ceef1d46c415af80a09808a984db4c42a88d65d644a8b"
-patched = "408496eb2cca51c0563eceaa3a9def95a5c42acff938850a8577aaa047331284"
+original = "2aa90f0b00f31e4ee906e232b8f8c7760a32db32629b753982fe133e3399ad7d"
+patched = "719cb4a7df3ff8e310d92701a9a25209dc315d25de2c2311d872f72689fc98b1"
 
 [profile.pixel_v3.hashes_seekable]
-original = "63505cfd7c2c9d948a5ee150cf53f448f11c83cdce3919fd43231640bf002812"
-patched = "b246497de1588d41b919ba002b37dff13cb565682aa3e086e543b25ead7d7aaf"
+original = "1a7d2f3672c61fdca6a22be12a356020533fa5d79c9a2eef9e77d68413ae5f96"
+patched = "5d8e775f019eb1fd7f999a59d95aea083eb3e58a1e62be051a25fd30de0fc12c"
 
 # Google Pixel 4a
 # What's unique: boot (boot v2)
@@ -169,9 +169,9 @@ data.type = "vbmeta"
 data.deps = ["system"]
 
 [profile.pixel_v2.hashes_streaming]
-original = "c303728f4ee9c42ef990bb576bd0688635b263a67127d2a986caf574c9eedd63"
-patched = "e907db408767f81223e3ae53dd8a44c6f59f4702a016093cd6983499c9391ff0"
+original = "9022288fc42beae948481007effc237f125fcb0f50a80233ab684b8b3cb302fa"
+patched = "d97ef57bc386e4ba218d233cc23c6ce69ddabda68343d1139412d7e17ed4ffa9"
 
 [profile.pixel_v2.hashes_seekable]
-original = "951b1f70bef7736b9e06f3215357fcebf8a4925872cd31691198fdda9d7c04ce"
-patched = "2b1bfe46f41942be88e09b40000745c68ed133900d7970f57d15019683a1ba87"
+original = "36c1413d174b724faafb7b7c1f63fb1ccb11f1eb597940d1e688aa149ae2ba1c"
+patched = "d4c0fd403440c8c11bae3d83e24b711b185c25e147da42370e361b4e87a564c2"


### PR DESCRIPTION
rawzip is a lower-level zip file library that is much more suited for avbroot's use case. Its speed improvements aren't too important since OTAs only have a handful of files, but it is a simpler layer of abstraction and exposes more about zip file internals. We also no longer need to maintain a perpetual fork of the zip library.

The only caveat is that rawzip (much like avbroot) is built around writing zip files in a streaming fashion. To support `--zip-mode seekable`, the output file is post-processed to copy the relevant data descriptor fields to the local header. The unused data descriptors remain in the file to avoid needing to shift file data, but this does not violate the spec and Android's libziparchive accepts it just fine.

---

I currently don't plan to merge this until these PRs are merged:

* [x] https://github.com/nickbabcock/rawzip/pull/99
  * When using `--zip-mode seekable`, we need to reserve space equal to the size of a ZIP64 extra field in the local header, but the bug causes the wrong extra fields to be written in the central header.

These would be nice to have, but we currently have workarounds for them, so they won't block merging:

* [x] https://github.com/nickbabcock/rawzip/issues/97
  * We currently parse the central headers ourselves when converting a streaming zip to a non-streaming zip with `--zip-mode seekable`.
* [x] https://github.com/nickbabcock/rawzip/pull/98
  * Just a minor quality of life change to avoid needing a `&mut` when we need to reuse the file that was passed to `ZipArchive`.
* [x] https://github.com/nickbabcock/rawzip/pull/100
  * If this is merged, we no longer need to wire up our `PSeekFile` to `ReaderAt` to accomplish the same thing.
* [x] https://github.com/nickbabcock/rawzip/issues/101
  * Quality of life change that'll make it easier to add our own function for UTF-8 file path validation.