### PR TITLE
Replace file reopen concept with ReadAt/WriteAt traits

### DIFF
--- a/avbroot/src/cli/hashtree.rs
+++ b/avbroot/src/cli/hashtree.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
@@ -13,15 +13,14 @@ use clap::{Parser, Subcommand};
 
 use crate::{
     format::hashtree::HashTreeImage,
-    stream::{FromReader, PSeekFile, ToWriter},
+    stream::{FromReader, ToWriter},
 };
 
-fn open_input(path: &Path, rw: bool) -> Result<PSeekFile> {
+fn open_input(path: &Path, rw: bool) -> Result<File> {
     OpenOptions::new()
         .read(true)
         .write(rw)
         .open(path)
-        .map(PSeekFile::new)
         .with_context(|| format!("Failed to open file: {path:?}"))
 }
 

--- a/avbroot/src/format/sparse.rs
+++ b/avbroot/src/format/sparse.rs
@@ -1026,7 +1026,7 @@ impl<W: Write> Write for SparseWriter<W> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Chunk, ChunkBounds, ChunkData, ChunkList};
+    use super::*;
 
     #[test]
     fn chunk_list_merge() {


### PR DESCRIPTION
File reopening was conflating ownership of file-like types with the fact that they support parallel reads and writes at arbitrary offsets.

The `Reopen` trait has now been replaced with `ReadAt` and `WriteAt` traits, which are implemented for types that support parallel I/O. If a type compatible with the standard `Read`/`Write`/`Seek` traits is needed, a new `UserPosFile` type can act as the bridge by storing its own userspace file offset. For the opposite bridge, there's `MutexFile`, which implements `ReadAt`/`WriteAt` by using locks to make the operations sequential. This is only really used in the tests though.

This eliminates the need for the `PSeekFile` and `SharedCursor` types. The standard `File` and `Cursor` types can be used instead, and if shared ownership is needed, `Arc` can be used.