### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,15 +80,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "assert_matches"
@@ -192,14 +192,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 dependencies = [
  "serde",
 ]
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.43"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -338,23 +338,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd"
+checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -527,7 +527,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -753,9 +753,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -812,9 +812,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -875,7 +875,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "lzma-rust2"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82192ab5b40bc95fff6e8a61e099e421f07055778b2f5261297c102137b6081"
+checksum = "fb31493965215fc8d0956b8dd58f2609e17ea89487a5cb2619e1d60b8b71328f"
 dependencies = [
  "crc",
  "sha2",
@@ -914,9 +914,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
 ]
@@ -940,7 +940,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1198,19 +1198,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1241,7 +1241,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.106",
  "tempfile",
 ]
 
@@ -1255,7 +1255,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1353,14 +1353,15 @@ dependencies = [
 
 [[package]]
 name = "rawzip"
-version = "0.3.1"
-source = "git+https://github.com/nickbabcock/rawzip?rev=562b92b73df135829b593abd29892ca73fa7b51a#562b92b73df135829b593abd29892ca73fa7b51a"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439c3cea2f04ab9cf078fab95c153af562df27cca8fbf88c0a7499c3f389ce23"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1368,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1512,7 +1513,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1630,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1661,35 +1662,35 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1719,7 +1720,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1733,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d3b47e6b7a040216ae5302712c94d1cf88c95b47efa80e2c59ce96c878267e"
+checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
 dependencies = [
  "indexmap",
  "serde",
@@ -1786,7 +1787,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2073,9 +2074,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -2130,7 +2131,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2150,7 +2151,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -27,7 +27,7 @@ flate2 = { version = "1.0.29", features = ["zlib-rs"] }
 gf256 = { version = "0.3.0", features = ["rs"] }
 hex = { version = "0.4.3", features = ["serde"] }
 lz4_flex = "0.11.1"
-lzma-rust2 = "0.8.0"
+lzma-rust2 = "0.10.0"
 memchr = "2.6.0"
 num-bigint-dig = "0.8.4"
 num-traits = "0.2.16"
@@ -37,6 +37,7 @@ pkcs8 = { version = "0.10.2", features = ["encryption", "pem"] }
 prost = "0.14.1"
 # We can't upgrade to 0.9.0 until rsa updates its rand_core dependency.
 rand = "0.8.5"
+rawzip = "0.4.0"
 rayon = "1.7.0"
 regex = { version = "1.9.4", default-features = false, features = ["perf", "std"] }
 # We use ring instead of sha2 for sha256 digest computation of large files
@@ -57,10 +58,6 @@ tracing-subscriber = "0.3.18"
 x509-cert = { version = "0.2.4", features = ["builder"] }
 zerocopy = { version = "0.8.10", features = ["std"] }
 zerocopy-derive = "0.8.5"
-
-[dependencies.rawzip]
-git = "https://github.com/nickbabcock/rawzip"
-rev = "562b92b73df135829b593abd29892ca73fa7b51a"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.158"

--- a/avbroot/src/cli/cpio.rs
+++ b/avbroot/src/cli/cpio.rs
@@ -33,7 +33,7 @@ fn open_reader(
     path: &Path,
     include_trailer: bool,
 ) -> Result<(
-    CpioReader<CompressedReader<'_, BufReader<File>>>,
+    CpioReader<CompressedReader<BufReader<File>>>,
     CompressedFormat,
 )> {
     let file =
@@ -49,7 +49,7 @@ fn open_reader(
 fn open_writer(
     path: &Path,
     format: CompressedFormat,
-) -> Result<CpioWriter<CompressedWriter<'_, BufWriter<File>>>> {
+) -> Result<CpioWriter<CompressedWriter<BufWriter<File>>>> {
     let file =
         File::create(path).with_context(|| format!("Failed to open cpio for writing: {path:?}"))?;
     let writer = CompressedWriter::new(BufWriter::new(file), format)

--- a/avbroot/src/format/ota.rs
+++ b/avbroot/src/format/ota.rs
@@ -18,9 +18,7 @@ use cms::signed_data::SignedData;
 use const_oid::{ObjectIdentifier, db::rfc5912};
 use memchr::memmem;
 use prost::Message;
-use rawzip::{
-    CompressionMethod, RECOMMENDED_BUFFER_SIZE, ZipArchive, ZipArchiveWriter, ZipDataWriter,
-};
+use rawzip::{CompressionMethod, RECOMMENDED_BUFFER_SIZE, ZipArchive, ZipArchiveWriter};
 use ring::digest::{Algorithm, Context};
 use thiserror::Error;
 use x509_cert::{Certificate, der::Encode};
@@ -519,12 +517,12 @@ pub fn add_metadata(
         path: &'static str,
         data: &[u8],
     ) -> Result<(u64, u64)> {
-        let entry_writer = archive
+        let (entry_writer, data_config) = archive
             .new_file(path)
-            .create()
+            .start()
             .map_err(|e| Error::ZipEntryStart(path.into(), e))?;
         let data_offset = entry_writer.stream_offset();
-        let mut data_writer = ZipDataWriter::new(entry_writer);
+        let mut data_writer = data_config.wrap(entry_writer);
 
         data_writer
             .write_all(data)

--- a/avbroot/src/format/zip.rs
+++ b/avbroot/src/format/zip.rs
@@ -246,7 +246,7 @@ fn compression_method_to_format(
 pub fn compressed_reader<'archive, R: ReaderAt>(
     entry: &ZipEntry<'archive, R>,
     compression_method: CompressionMethod,
-) -> Result<CompressedReader<'archive, ZipReader<&'archive R>>, rawzip::Error> {
+) -> Result<CompressedReader<ZipReader<&'archive R>>, rawzip::Error> {
     let format = compression_method_to_format(compression_method)?;
 
     Ok(CompressedReader::with_format(entry.reader(), format))
@@ -255,7 +255,7 @@ pub fn compressed_reader<'archive, R: ReaderAt>(
 pub fn compressed_slice_reader<'archive>(
     entry: &ZipSliceEntry<'archive>,
     compression_method: CompressionMethod,
-) -> Result<CompressedReader<'archive, Cursor<&'archive [u8]>>, rawzip::Error> {
+) -> Result<CompressedReader<Cursor<&'archive [u8]>>, rawzip::Error> {
     let format = compression_method_to_format(compression_method)?;
     let raw_reader = Cursor::new(entry.data());
 
@@ -265,24 +265,21 @@ pub fn compressed_slice_reader<'archive>(
 pub fn verifying_reader<'archive, R: ReaderAt>(
     entry: &ZipEntry<'archive, R>,
     compression_method: CompressionMethod,
-) -> Result<
-    ZipVerifier<'archive, CompressedReader<'archive, ZipReader<&'archive R>>, R>,
-    rawzip::Error,
-> {
+) -> Result<ZipVerifier<CompressedReader<ZipReader<&'archive R>>, &'archive R>, rawzip::Error> {
     compressed_reader(entry, compression_method).map(|r| entry.verifying_reader(r))
 }
 
 pub fn verifying_slice_reader<'archive>(
     entry: &ZipSliceEntry<'archive>,
     compression_method: CompressionMethod,
-) -> Result<ZipSliceVerifier<CompressedReader<'archive, Cursor<&'archive [u8]>>>, rawzip::Error> {
+) -> Result<ZipSliceVerifier<CompressedReader<Cursor<&'archive [u8]>>>, rawzip::Error> {
     compressed_slice_reader(entry, compression_method).map(|r| entry.verifying_reader(r))
 }
 
-pub fn compressed_writer<'writer, W: Write + 'writer>(
+pub fn compressed_writer<W: Write>(
     writer: W,
     compression_method: CompressionMethod,
-) -> Result<CompressedWriter<'writer, W>, rawzip::Error> {
+) -> Result<CompressedWriter<W>, rawzip::Error> {
     use compression::Error;
 
     let format = compression_method_to_format(compression_method)?;

--- a/deny.toml
+++ b/deny.toml
@@ -72,5 +72,4 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
     "https://github.com/chenxiaolong/system-properties",
-    "https://github.com/nickbabcock/rawzip",
 ]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -14,6 +14,7 @@ avbroot = { path = "../avbroot" }
 clap = { version = "4.4.1", features = ["derive"] }
 ctrlc = "3.4.0"
 hex = { version = "0.4.3", features = ["serde"] }
+rawzip = "0.4.0"
 ring = "0.17.14"
 rsa = { version = "0.9.6", features = ["hazmat"] }
 serde = { version = "1.0.188", features = ["derive"] }
@@ -23,10 +24,6 @@ topological-sort = "0.2.2"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 x509-cert = "0.2.5"
-
-[dependencies.rawzip]
-git = "https://github.com/nickbabcock/rawzip"
-rev = "562b92b73df135829b593abd29892ca73fa7b51a"
 
 [lints]
 workspace = true

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -51,12 +51,12 @@ data.version = "vendor_v4"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v4_gki.hashes_streaming]
-original = "3638d2e253e0647c4aa2d26301522d0c4b98d4c190115f04741066e2c8f25d7c"
-patched = "be9a67884bdae4d04040e8b525cdf6f9c3d2d4ee816154843219192cc2671479"
+original = "ea96196191e3a4133db4aff45d47aa3468514e29e0a724faac8081cbf4adf808"
+patched = "357a448d1a7505b2308ce1c2d19b063e606c60e7349784913a48cdc3f6d50aa4"
 
 [profile.pixel_v4_gki.hashes_seekable]
-original = "acbc1e5af57390b10d5f7fe3770e47b4db0c7200f9e1d63036fdb8c53c60e3e5"
-patched = "6e4bb1967045238cf02a61d422c2d9e4b40f21cb0d19e2ea548091d49808b7a9"
+original = "f6615ae355eba38689d24aa535981d09175d4832e7c65c04cdd89aa95d21f09d"
+patched = "9195ba963d9897af2f0821ff6051c1efe3fe130055b7936bedf2cd189998fd89"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)
@@ -93,12 +93,12 @@ data.version = "vendor_v4"
 data.ramdisks = [["init", "otacerts", "first_stage", "dsu_key_dir"], ["dlkm"]]
 
 [profile.pixel_v4_non_gki.hashes_streaming]
-original = "1785927b7768675ea7d261cf44f659b7402cf1799b636fd9f55b420f6e04b40d"
-patched = "62d1fd1ff5f37d140cfaa3ca584a457144724e5ca3cff2c23c233f0a87037a74"
+original = "cb2a2e406d2b4c68c8a38f819256a10ada0ed5a4732822bec35bdf7bcdc458eb"
+patched = "12f15d29fceeb18af14c9a805de3aedb7f270fe8ec316d9d0fe37fb0c667eacd"
 
 [profile.pixel_v4_non_gki.hashes_seekable]
-original = "46de37c516db66b254629ff21a0addf5524fe33c253b4c0dfc0a93d6405d7093"
-patched = "45f2341c7d5aa31a412418672067ffe95f451f132cb16f049c257099727cef77"
+original = "9450c212c34fe55453b52345c7cc22f72397dc80d9ddc792eafc20b461c2afc9"
+patched = "5018c579df9608f9dfe3add2afd8b176de61ba267376cf3a3e422ecc9d3dd112"
 
 # Google Pixel 4a 5G
 # What's unique: boot (boot v3) + vendor_boot (vendor v3)
@@ -136,12 +136,12 @@ data.version = "vendor_v3"
 data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v3.hashes_streaming]
-original = "2aa90f0b00f31e4ee906e232b8f8c7760a32db32629b753982fe133e3399ad7d"
-patched = "719cb4a7df3ff8e310d92701a9a25209dc315d25de2c2311d872f72689fc98b1"
+original = "ae0dbd3055cc86db7df3c3cea89d826f021a860c7b7bbaed44d5ef93e2effcd3"
+patched = "ffe5cdc880468ebf3a2f30b495b56a196f9d0b9b2664acaf837a4084ade84317"
 
 [profile.pixel_v3.hashes_seekable]
-original = "1a7d2f3672c61fdca6a22be12a356020533fa5d79c9a2eef9e77d68413ae5f96"
-patched = "5d8e775f019eb1fd7f999a59d95aea083eb3e58a1e62be051a25fd30de0fc12c"
+original = "e9459df822703aac48f56755ada2327dccd4067d880a7a43974db139e7fbc155"
+patched = "3108c5163baf0ce5839167d88f78604ae06c2add5deabee24375d918288b1640"
 
 # Google Pixel 4a
 # What's unique: boot (boot v2)
@@ -169,9 +169,9 @@ data.type = "vbmeta"
 data.deps = ["system"]
 
 [profile.pixel_v2.hashes_streaming]
-original = "9022288fc42beae948481007effc237f125fcb0f50a80233ab684b8b3cb302fa"
-patched = "d97ef57bc386e4ba218d233cc23c6ce69ddabda68343d1139412d7e17ed4ffa9"
+original = "abc0ad7f80020018101437c2494d6564a877df663d208a123267fc100734c175"
+patched = "b1876455f5be9d5b6eafc598a017ad10e5e76339137f8b29777097ab19cdc3b0"
 
 [profile.pixel_v2.hashes_seekable]
-original = "36c1413d174b724faafb7b7c1f63fb1ccb11f1eb597940d1e688aa149ae2ba1c"
-patched = "d4c0fd403440c8c11bae3d83e24b711b185c25e147da42370e361b4e87a564c2"
+original = "57d4ac5ab7d362a593f3c02f3d2044b5400c10db0f732741a2d18e025d4231ec"
+patched = "40d7674be14e19747e7ead118e0f4faf50880c638dfb4bfc0d0154b0e9202d3f"


### PR DESCRIPTION
The e2e checksums were updated because the new lzma-rust2 version has slight differences in compression ratio.