### PR TITLE
format/payload: Fix out-of-order multithreaded writes

### DIFF
--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::{OsStr, OsString},
     fs::{self, File},
-    io::{self, BufReader, BufWriter, Cursor, Read, Seek, SeekFrom, Write},
+    io::{self, BufReader, Cursor, Read, Seek, SeekFrom, Write},
     ops::Range,
     path::{Path, PathBuf},
     str::FromStr,
@@ -1344,7 +1344,7 @@ pub fn extract_payload(
     // Extract the images.
     payload::extract_images(
         &payload_reader,
-        |name| Ok(Box::new(BufWriter::new(output_files[name].clone()))),
+        |name| Ok(Box::new(output_files[name].clone())),
         header,
         images.iter().map(|n| n.as_str()),
         cancel_signal,


### PR DESCRIPTION
This was a regression from d874921a69f3b503cc0ddb57f620607a28ffb82c. `extract_images()`'s `open_output` parameter was requesting a `WriteSeek` instead of a `WriteAt`, so it received multiple instances of `Arc<File>` all with the same underlying `File` (and file offset).