### PR TITLE
cli/payload: Compute CoW size estimates during packing

### DIFF
--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -830,7 +830,7 @@ pub fn compress_image(
 
 /// Recompute the CoW estimate for an image and update the OTA manifest
 /// partition entry appropriately. The input file is not modified.
-fn recow_image(
+pub fn recow_image(
     name: &str,
     file: &File,
     header: &mut PayloadHeader,


### PR DESCRIPTION
This was overlooked during the initial implementation. Payload images using VABC, but without CoW size estimates, are unflashable outside of recovery.