### PR TITLE
cli: Allow skipping unpacking of images

### DIFF
--- a/avbroot/src/cli/avb.rs
+++ b/avbroot/src/cli/avb.rs
@@ -735,7 +735,7 @@ fn unpack_subcommand(cli: &UnpackCli, cancel_signal: &AtomicBool) -> Result<()> 
 
     write_info(&cli.output_info, &info)?;
 
-    if info.footer.is_some() {
+    if info.footer.is_some() && !cli.no_output_raw {
         write_raw_and_verify(
             &cli.output_raw,
             &mut reader,
@@ -1024,6 +1024,10 @@ struct UnpackCli {
     /// Only appended AVB images will have a raw image.
     #[arg(long, value_name = "FILE", value_parser, default_value = "raw.img")]
     output_raw: PathBuf,
+
+    /// Do not output raw image.
+    #[arg(long, conflicts_with = "output_raw")]
+    no_output_raw: bool,
 
     /// Ignore invalid digests or FEC data.
     #[arg(long)]

--- a/avbroot/src/cli/boot.rs
+++ b/avbroot/src/cli/boot.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
@@ -164,30 +164,44 @@ fn unpack_subcommand(boot_cli: &BootCli, cli: &UnpackCli) -> Result<()> {
         }
     }
 
-    if let Some(data) = kernel {
+    if let Some(data) = kernel
+        && !cli.no_output_kernel
+    {
         write_data_if_not_empty(&cli.output_kernel, data)?;
     }
-    if let Some(data) = second {
+    if let Some(data) = second
+        && !cli.no_output_second
+    {
         write_data_if_not_empty(&cli.output_second, data)?;
     }
-    if let Some(data) = recovery_dtbo {
+    if let Some(data) = recovery_dtbo
+        && !cli.no_output_recovery_dtbo
+    {
         write_data_if_not_empty(&cli.output_recovery_dtbo, data)?;
     }
-    if let Some(data) = dtb {
+    if let Some(data) = dtb
+        && !cli.no_output_dtb
+    {
         write_data_if_not_empty(&cli.output_dtb, data)?;
     }
-    if let Some(header) = vts_signature {
+    if let Some(header) = vts_signature
+        && !cli.no_output_vts_signature
+    {
         write_avb_header(&cli.output_vts_signature, header)?;
     }
-    if let Some(text) = bootconfig {
+    if let Some(text) = bootconfig
+        && !cli.no_output_bootconfig
+    {
         write_text_if_not_empty(&cli.output_bootconfig, text)?;
     }
 
-    for (i, data) in ramdisks.iter().enumerate() {
-        let mut path = cli.output_ramdisk_prefix.as_os_str().to_owned();
-        path.push(i.to_string());
+    if !cli.no_output_ramdisk {
+        for (i, data) in ramdisks.iter().enumerate() {
+            let mut path = cli.output_ramdisk_prefix.as_os_str().to_owned();
+            path.push(i.to_string());
 
-        write_data_if_not_empty(Path::new(&path), data)?;
+            write_data_if_not_empty(Path::new(&path), data)?;
+        }
     }
 
     Ok(())
@@ -339,6 +353,10 @@ struct UnpackCli {
     #[arg(long, value_name = "FILE", value_parser, default_value = "kernel.img")]
     output_kernel: PathBuf,
 
+    /// Do not output kernel image.
+    #[arg(long, conflicts_with = "output_kernel")]
+    no_output_kernel: bool,
+
     /// Path prefix for output ramdisk images.
     #[arg(
         long,
@@ -348,9 +366,17 @@ struct UnpackCli {
     )]
     output_ramdisk_prefix: PathBuf,
 
+    /// Do not output ramdisk images.
+    #[arg(long, conflicts_with = "output_ramdisk_prefix")]
+    no_output_ramdisk: bool,
+
     /// Path to output second stage bootloader image.
     #[arg(long, value_name = "FILE", value_parser, default_value = "second.img")]
     output_second: PathBuf,
+
+    /// Do not output second stage bootloader image.
+    #[arg(long, conflicts_with = "output_second")]
+    no_output_second: bool,
 
     /// Path to output recovery dtbo/acpio image.
     #[arg(
@@ -361,9 +387,17 @@ struct UnpackCli {
     )]
     output_recovery_dtbo: PathBuf,
 
+    /// Do not output recovery dtbo/acpio image.
+    #[arg(long, conflicts_with = "output_recovery_dtbo")]
+    no_output_recovery_dtbo: bool,
+
     /// Path to output device tree blob image.
     #[arg(long, value_name = "FILE", value_parser, default_value = "dtb.img")]
     output_dtb: PathBuf,
+
+    /// Do not output device tree blob image.
+    #[arg(long, conflicts_with = "output_dtb")]
+    no_output_dtb: bool,
 
     /// Path to output VTS signature.
     #[arg(
@@ -374,6 +408,10 @@ struct UnpackCli {
     )]
     output_vts_signature: PathBuf,
 
+    /// Do not output VTS signature.
+    #[arg(long, conflicts_with = "output_vts_signature")]
+    no_output_vts_signature: bool,
+
     /// Path to output bootconfig text.
     #[arg(
         long,
@@ -382,6 +420,10 @@ struct UnpackCli {
         default_value = "bootconfig.txt"
     )]
     output_bootconfig: PathBuf,
+
+    /// Do not output bootconfig text.
+    #[arg(long, conflicts_with = "output_bootconfig")]
+    no_output_bootconfig: bool,
 }
 
 /// Pack a boot image.

--- a/avbroot/src/cli/lp.rs
+++ b/avbroot/src/cli/lp.rs
@@ -179,7 +179,7 @@ fn unpack_subcommand(lp_cli: &LpCli, cli: &UnpackCli, cancel_signal: &AtomicBool
     write_info(&cli.output_info, &metadata)?;
 
     // For empty images, there's no data to unpack.
-    if metadata.image_type == ImageType::Empty {
+    if metadata.image_type == ImageType::Empty || cli.no_output_images {
         return Ok(());
     }
 
@@ -534,6 +534,10 @@ struct UnpackCli {
     /// Path to output images directory.
     #[arg(long, value_name = "DIR", value_parser, default_value = "lp_images")]
     output_images: PathBuf,
+
+    /// Do not output images.
+    #[arg(long, conflicts_with = "output_images")]
+    no_output_images: bool,
 
     /// The LP metadata slot to use.
     ///

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -113,24 +113,26 @@ fn unpack_subcommand(
 
     write_info(&cli.output_info, &header)?;
 
-    fs::create_dir_all(&cli.output_images)
-        .with_context(|| format!("Failed to create directory: {:?}", cli.output_images))?;
+    if !cli.no_output_images {
+        fs::create_dir_all(&cli.output_images)
+            .with_context(|| format!("Failed to create directory: {:?}", cli.output_images))?;
 
-    ota::extract_payload(
-        &reader.into_inner(),
-        &cli.output_images,
-        0,
-        payload_size,
-        &header,
-        &header
-            .manifest
-            .partitions
-            .iter()
-            .map(|p| &p.partition_name)
-            .cloned()
-            .collect(),
-        cancel_signal,
-    )?;
+        ota::extract_payload(
+            &reader.into_inner(),
+            &cli.output_images,
+            0,
+            payload_size,
+            &header,
+            &header
+                .manifest
+                .partitions
+                .iter()
+                .map(|p| &p.partition_name)
+                .cloned()
+                .collect(),
+            cancel_signal,
+        )?;
+    }
 
     Ok(())
 }
@@ -386,6 +388,10 @@ struct UnpackCli {
         default_value = "payload_images"
     )]
     output_images: PathBuf,
+
+    /// Do not output images.
+    #[arg(long, conflicts_with = "output_images")]
+    no_output_images: bool,
 }
 
 /// Pack a payload binary.


### PR DESCRIPTION
This is useful if the file format metadata is the only thing that the user needs.