### PR TITLE
Add aarch64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
             targets:
               - aarch64-linux-android
             android_api: '31'
+          - os: ubuntu-24.04-arm
+            name: aarch64-unknown-linux-gnu
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
There are currently no prebuilt ARM binaries for GNU/Linux (the cross-compiled Android builds may or may not work on non-Android systems).

This PR adds `aarch64-unknown-linux-gnu`  as a build target, compiled natively on GitHub-hosted arm64 runners during the CI workflow.

I am unsure whether additional changes are required to add the new artifact as release asset.