### PR TITLE
patch/boot: Add support for DSU on dedicated recovery devices

### DIFF
--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -2066,10 +2066,10 @@ pub fn verify_subcommand(cli: &VerifyCli, cancel_signal: &AtomicBool) -> Result<
         }
     }
 
-    let boot_images = boot::load_boot_images(&boot_image_names, &Opener(temp_dir.path()))
+    let (boot_images, layout) = boot::load_boot_images(&boot_image_names, &Opener(temp_dir.path()))
         .context("Failed to load all boot images")?;
     let targets = OtaCertPatcher::new(ota_cert.clone())
-        .find_targets(&boot_images, cancel_signal)
+        .find_targets(layout, &boot_images, cancel_signal)
         .context("Failed to find boot image containing otacerts.zip")?;
 
     if targets.is_empty() {


### PR DESCRIPTION
On devices with dedicated recovery partitions, `first_stage_ramdisk` exists in the ramdisks, but is unused. The first stage switch root operation is just skipped. To properly add a public key for DSU on these devices, the top level `/avb` directory needs to be used.

Fixes: #536