### PR TITLE
Update toml to support serialization of large u64 values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.10+spec-1.1.0"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -53,7 +53,7 @@ sha1 = "0.10.5"
 sha2 = "0.10.7"
 tempfile = "3.8.0"
 thiserror = "2.0.3"
-toml = { version = "0.9.10", features = ["serde"] }
+toml = { version = "0.9.11", features = ["serde"] }
 topological-sort = "0.2.2"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/fuzz/corpus/bootimage/boot_v2/boot.toml
+++ b/fuzz/corpus/bootimage/boot_v2/boot.toml
@@ -23,7 +23,4 @@ extra_cmdline = "ExtraCmdlineExtraCmdlineExtraCmdlineExtraCmdlineExtraCmdlineExt
 recovery_dtbo_offset = 81985529216486895
 
 [v2_extra]
-# Unpacking the generated image will currently fail due to toml not supporting
-# serialization of integers larger than i64::MAX:
-# https://github.com/toml-rs/toml/issues/1085
 dtb_addr = 18364758544493064720


### PR DESCRIPTION
Upstream bug report: https://github.com/toml-rs/toml/issues/1085
Upstream fix: https://github.com/toml-rs/toml/pull/1086