### PR TITLE
cli/{cpio,lp,payload}: Remove outdated mention of openat-style sandboxing

### DIFF
--- a/avbroot/src/cli/cpio.rs
+++ b/avbroot/src/cli/cpio.rs
@@ -287,8 +287,7 @@ pub fn cpio_main(cli: &CpioCli, cancel_signal: &AtomicBool) -> Result<()> {
 /// TOML file, like the UID/GID, permissions, and symlink targets.
 ///
 /// If any paths inside the cpio archive are unsafe, the extraction process will
-/// fail and exit. Extracted files are never written outside of the tree
-/// directory, even if an external process tries to interfere.
+/// fail and exit.
 #[derive(Debug, Parser)]
 struct UnpackCli {
     /// Path to input cpio file.

--- a/avbroot/src/cli/lp.rs
+++ b/avbroot/src/cli/lp.rs
@@ -515,8 +515,7 @@ pub fn lp_main(cli: &LpCli, cancel_signal: &AtomicBool) -> Result<()> {
 /// directory. For empty images, the output images directory is unused.
 ///
 /// If any partition names are unsafe to use in a path, the extraction process
-/// will fail and exit. Extracted files are never written outside of the tree
-/// directory, even if an external process tries to interfere.
+/// will fail and exit.
 #[derive(Debug, Parser)]
 struct UnpackCli {
     /// Path to input LP images.

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -363,8 +363,7 @@ struct KeyGroup {
 /// directory. The payload header metadata is written to the info TOML file.
 ///
 /// If any partition names are unsafe to use in a path, the extraction process
-/// will fail and exit. Extracted files are never written outside of the tree
-/// directory, even if an external process tries to interfere.
+/// will fail and exit.
 #[derive(Debug, Parser)]
 struct UnpackCli {
     /// Path to input payload binary.


### PR DESCRIPTION
This was previously removed in d7369e73e916305c3cde577aa0e1073c3eaf607f because it was preventing other legitimate use cases.