### PR TITLE
Add support for unpacking and packing raw OTA zips

### DIFF
--- a/README.extra.md
+++ b/README.extra.md
@@ -52,6 +52,8 @@ avbroot avb info -i <image>
 
 This subcommand shows all of the vbmeta header and footer fields. `vbmeta` partition images will only have a header, while partitions with actual data (eg. boot images) will have both a header and a footer.
 
+(The `unpack`, `pack`, and `repack` subcommands also show this information. This specific subcommand just does so without performing any other operation.)
+
 ### Verifying AVB hashes and signatures
 
 ```bash
@@ -117,7 +119,9 @@ This subcommand repacks a boot image without writing the individual components t
 avbroot boot info -i <input boot image>
 ```
 
-All of the `boot` subcommands show the boot image information. This specific subcommand just does it without performing any other operation. To show avbroot's internal representation of the information, pass in `-d`.
+This subcommand shows the information contained in the boot image's header. To show avbroot's internal representation of the information, pass in `-d`.
+
+(All of the `boot` subcommands show this information. This specific subcommand just does so without performing any other operation.)
 
 ## `avbroot cpio`
 
@@ -159,7 +163,9 @@ This is almost equivalent to running `avbroot cpio unpack` followed by `avbroot 
 avbroot cpio info -i <input cpio archive>
 ```
 
-All of the `cpio` subcommands show details about all the entries in the archive. This specific subcommand just does it without performing any other operation.
+This subcommand shows details about every entry in the archive.
+
+(All of the `cpio` subcommands show this information. This specific subcommand just does so without performing any other operation.)
 
 ## `avbroot fec`
 
@@ -320,6 +326,8 @@ avbroot lp info -i <first LP image>
 
 This subcommand shows the LP image metadata, including all metadata slots. If there are multiple images, only the first one is needed because it is the only one that stores the metadata.
 
+(All of the `lp` subcommands show this information. This specific subcommand just does so without performing any other operation.)
+
 ## `avbroot payload`
 
 This set of commands is for working with payload binary files (`payload.bin`). The `unpack` and `pack` commands can only work with full payloads because they require the complete data to be available, but the `repack` and `info` commands also work with delta payloads.
@@ -361,6 +369,8 @@ avbroot payload info -i <payload>
 ```
 
 This subcommand shows all of the payload header fields (which will likely be extremely long).
+
+(All of the `payload` subcommands show this information. This specific subcommand just does so without performing any other operation.)
 
 ## `avbroot sparse`
 
@@ -405,3 +415,49 @@ avbroot sparse info -i <input sparse image>
 ```
 
 This subcommand shows the sparse image metadata, including the header and all chunks.
+
+(All of the `sparse` subcommands show this information. This specific subcommand just does so without performing any other operation.)
+
+## `avbroot zip`
+
+This set of commands is for working with raw OTA zip files. They are intentionally placed outside of `avbroot ota` to make them less discoverable by accident. These commands are useful for creating OTA zip files without going through the normal `avbroot ota patch` mechanism.
+
+**WARNING**: Make sure to run `avbroot ota verify` on OTA files before installing them. These pack commands are low level operations that only check that the file structure of the OTA itself is valid, not the contents contained within.
+
+### Unpacking an OTA zip
+
+```bash
+avbroot ota unpack -i <input OTA>
+```
+
+This subcommand unpacks the OTA metadata to `ota.toml` and the OTA files to the `ota_files` directory.
+
+### Packing an OTA zip
+
+```bash
+avbroot ota pack -o <output OTA> --key <OTA private key>
+```
+
+This subcommand packs a new OTA zip from the `ota.toml` file and `ota_files` directory. Any files in the `ota_files` directory that don't have a corresponding entry in `ota.toml` are silently ignored.
+
+When packing an OTA zip, the `metadata.property_files` field in `ota.toml` may potentially be recomputed. To write a TOML file containing the new values, use `--output-info <output TOML>`. It is safe to overwrite the existing `ota.toml` if desired.
+
+### Repacking an OTA zip
+
+```bash
+avbroot ota repack -i <input OTA> -o <output OTA> --key <OTA private key>
+```
+
+This subcommand is logically equivalent to `avbroot ota unpack` followed by `avbroot ota pack`, except more efficient.
+
+**WARNING**: This is generally not a useful command. Resigning the OTA zip without also resigning the payload binary inside results in an invalid OTA.
+
+### Showing OTA metadata
+
+```bash
+avbroot ota info -i <input OTA>
+```
+
+This subcommand shows all of the OTA metadata fields. If both the modern protobuf metadata and the legacy plain text metadata exist, the protobuf metadata takes precedence.
+
+(All of the `ota` subcommands show this information. This specific subcommand just does so without performing any other operation.)

--- a/avbroot/src/cli/args.rs
+++ b/avbroot/src/cli/args.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
@@ -13,7 +13,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use tracing::{Level, debug};
 use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
 
-use crate::cli::{avb, boot, completion, cpio, fec, hashtree, key, lp, ota, payload, sparse};
+use crate::cli::{avb, boot, completion, cpio, fec, hashtree, key, lp, ota, payload, sparse, zip};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
@@ -29,6 +29,7 @@ pub enum Command {
     Ota(ota::OtaCli),
     Payload(payload::PayloadCli),
     Sparse(sparse::SparseCli),
+    Zip(zip::ZipCli),
     /// (Deprecated: Use `avbroot ota patch` instead.)
     #[command(hide = true)]
     Patch(ota::PatchCli),
@@ -132,6 +133,7 @@ pub fn main(logging_initialized: &AtomicBool, cancel_signal: &AtomicBool) -> Res
         Command::Ota(c) => ota::ota_main(&c, cancel_signal),
         Command::Payload(c) => payload::payload_main(&c, cancel_signal),
         Command::Sparse(c) => sparse::sparse_main(&c, cancel_signal),
+        Command::Zip(c) => zip::zip_main(&c, cancel_signal),
         // Deprecated aliases.
         Command::Patch(c) => ota::patch_subcommand(&c, cancel_signal),
         Command::Extract(c) => ota::extract_subcommand(&c, cancel_signal),

--- a/avbroot/src/cli/mod.rs
+++ b/avbroot/src/cli/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
 pub mod args;
@@ -13,3 +13,4 @@ pub mod lp;
 pub mod ota;
 pub mod payload;
 pub mod sparse;
+pub mod zip;

--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -1940,9 +1940,9 @@ pub fn verify_subcommand(cli: &VerifyCli, cancel_signal: &AtomicBool) -> Result<
         };
     }
 
-    let raw_reader = File::open(&cli.input)
+    let mut reader = File::open(&cli.input)
+        .map(BufReader::new)
         .with_context(|| format!("Failed to open for reading: {:?}", cli.input))?;
-    let mut reader = BufReader::new(raw_reader);
 
     info!("Verifying whole-file signature");
 
@@ -2193,7 +2193,7 @@ pub struct PatchCli {
         alias = "privkey-avb",
         value_name = "FILE",
         value_parser,
-        help_heading = HEADING_KEY
+        help_heading = HEADING_KEY,
     )]
     pub key_avb: PathBuf,
 
@@ -2206,7 +2206,7 @@ pub struct PatchCli {
         alias = "privkey-ota",
         value_name = "FILE",
         value_parser,
-        help_heading = HEADING_KEY
+        help_heading = HEADING_KEY,
     )]
     pub key_ota: PathBuf,
 
@@ -2221,7 +2221,7 @@ pub struct PatchCli {
         value_name = "ENV_VAR",
         value_parser,
         group = "pass_avb",
-        help_heading = HEADING_KEY
+        help_heading = HEADING_KEY,
     )]
     pub pass_avb_env_var: Option<OsString>,
 
@@ -2232,7 +2232,7 @@ pub struct PatchCli {
         value_name = "FILE",
         value_parser,
         group = "pass_avb",
-        help_heading = HEADING_KEY
+        help_heading = HEADING_KEY,
     )]
     pub pass_avb_file: Option<PathBuf>,
 
@@ -2243,7 +2243,7 @@ pub struct PatchCli {
         value_name = "ENV_VAR",
         value_parser,
         group = "pass_ota",
-        help_heading = HEADING_KEY
+        help_heading = HEADING_KEY,
     )]
     pub pass_ota_env_var: Option<OsString>,
 
@@ -2254,7 +2254,7 @@ pub struct PatchCli {
         value_name = "FILE",
         value_parser,
         group = "pass_ota",
-        help_heading = HEADING_KEY
+        help_heading = HEADING_KEY,
     )]
     pub pass_ota_file: Option<PathBuf>,
 
@@ -2273,7 +2273,7 @@ pub struct PatchCli {
         value_names = ["PARTITION", "FILE"],
         value_parser = value_parser!(OsString),
         num_args = 2,
-        help_heading = HEADING_PATH
+        help_heading = HEADING_PATH,
     )]
     pub replace: Vec<OsString>,
 
@@ -2285,7 +2285,7 @@ pub struct PatchCli {
         long,
         value_name = "PARTITION",
         conflicts_with_all = ["prepatched", "rootless"],
-        help_heading = HEADING_MAGISK
+        help_heading = HEADING_MAGISK,
     )]
     pub magisk_preinit_device: Option<String>,
 
@@ -2294,7 +2294,7 @@ pub struct PatchCli {
         long,
         value_name = "NUMBER",
         conflicts_with_all = ["prepatched", "rootless"],
-        help_heading = HEADING_MAGISK
+        help_heading = HEADING_MAGISK,
     )]
     pub magisk_random_seed: Option<u64>,
 
@@ -2302,7 +2302,7 @@ pub struct PatchCli {
     #[arg(
         long,
         conflicts_with_all = ["prepatched", "rootless"],
-        help_heading = HEADING_MAGISK
+        help_heading = HEADING_MAGISK,
     )]
     pub ignore_magisk_warnings: bool,
 
@@ -2311,7 +2311,7 @@ pub struct PatchCli {
         long,
         action = ArgAction::Count,
         conflicts_with_all = ["magisk", "rootless"],
-        help_heading = HEADING_PREPATCHED
+        help_heading = HEADING_PREPATCHED,
     )]
     pub ignore_prepatched_compat: u8,
 
@@ -2368,7 +2368,7 @@ pub struct PatchCli {
         long,
         value_name = "MODE",
         default_value_t = ZipMode::Streaming,
-        help_heading = HEADING_OTHER
+        help_heading = HEADING_OTHER,
     )]
     pub zip_mode: ZipMode,
 
@@ -2377,7 +2377,7 @@ pub struct PatchCli {
         long,
         value_name = "PARTITION",
         hide = true,
-        help_heading = HEADING_OTHER
+        help_heading = HEADING_OTHER,
     )]
     pub boot_partition: Option<String>,
 }

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -456,7 +456,7 @@ struct RepackCli {
 /// Display payload information.
 #[derive(Debug, Parser)]
 struct InfoCli {
-    /// Path to input payload file.
+    /// Path to input payload binary.
     #[arg(short, long, value_name = "FILE", value_parser)]
     input: PathBuf,
 }

--- a/avbroot/src/cli/zip.rs
+++ b/avbroot/src/cli/zip.rs
@@ -1,0 +1,629 @@
+// SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fs::{self, File, OpenOptions},
+    io::{BufReader, Seek},
+    path::{Path, PathBuf},
+    sync::atomic::AtomicBool,
+};
+
+use anyhow::{Context, Result, anyhow};
+use clap::{Args, Parser, Subcommand};
+use rawzip::{
+    CompressionMethod, RECOMMENDED_BUFFER_SIZE, ZipArchive, ZipArchiveEntryWayfinder,
+    ZipArchiveWriter, ZipDataWriter, ZipEntryWriter, extra_fields::ExtraFieldId,
+};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+use x509_cert::Certificate;
+
+use crate::{
+    crypto::{self, PassphraseSource, RsaSigningKey},
+    format::{
+        ota::{self, SigningWriter, ZipEntry, ZipMode},
+        payload::PayloadHeader,
+        zip::{
+            self, ReaderAtWrapper, ZipArchiveReadAtExt, ZipEntriesSafeExt, ZipFileHeaderRecordExt,
+        },
+    },
+    protobuf::build::tools::releasetools::OtaMetadata,
+    stream::{self, FromReader},
+    util,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct OtaInfo {
+    metadata: OtaMetadata,
+    files: Vec<String>,
+}
+
+struct InputEntry {
+    compression_method: CompressionMethod,
+    is_zip64: bool,
+    wayfinder: ZipArchiveEntryWayfinder,
+}
+
+fn is_excluded_path(path: &str) -> bool {
+    path == ota::PATH_METADATA || path == ota::PATH_METADATA_PB || path == ota::PATH_OTACERT
+}
+
+#[allow(clippy::type_complexity)]
+fn open_reader(
+    path: &Path,
+) -> Result<(
+    ZipArchive<ReaderAtWrapper<File>>,
+    OtaMetadata,
+    BTreeMap<String, InputEntry>,
+)> {
+    let mut reader =
+        File::open(path).with_context(|| format!("Failed to open OTA for reading: {path:?}"))?;
+
+    let (metadata, _, _, _) = ota::parse_zip_ota_info(&mut reader)
+        .with_context(|| format!("Failed to parse OTA metadata: {path:?}"))?;
+
+    let mut buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let zip_reader =
+        ZipArchive::from_read_at(reader, &mut buffer).context("Failed to read OTA zip")?;
+
+    let mut entries = zip_reader.entries_safe(&mut buffer);
+    let mut input_entries = BTreeMap::new();
+
+    while let Some((cd_entry, _)) = entries.next_entry().context("Failed to list zip entries")? {
+        if cd_entry.is_dir() {
+            continue;
+        }
+
+        let path = cd_entry
+            .file_path_utf8()
+            .context("Zip contains non-UTF-8 paths")?;
+
+        if is_excluded_path(path) {
+            // OTA metadata is never copied from the input file.
+            continue;
+        }
+
+        input_entries.insert(
+            path.to_owned(),
+            InputEntry {
+                compression_method: cd_entry.compression_method(),
+                // We only check for the sizes here instead of the presence of
+                // the ZIP64 extra field. The central header's extra fields may
+                // have ZIP64 only for the local header offset.
+                is_zip64: cd_entry.compressed_size_hint() >= 0xffffffff
+                    || cd_entry.uncompressed_size_hint() >= 0xffffffff,
+                wayfinder: cd_entry.wayfinder(),
+            },
+        );
+    }
+
+    Ok((zip_reader, metadata, input_entries))
+}
+
+fn open_writer(path: &Path, zip_mode: ZipMode) -> Result<ZipArchiveWriter<SigningWriter<File>>> {
+    let writer = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .with_context(|| format!("Failed to open OTA for writing: {path:?}"))?;
+
+    let signing_writer = match zip_mode {
+        ZipMode::Streaming => SigningWriter::new_streaming(writer),
+        ZipMode::Seekable => SigningWriter::new_seekable(writer),
+    };
+    let zip_writer = ZipArchiveWriter::new(signing_writer);
+
+    Ok(zip_writer)
+}
+
+fn read_info(path: &Path) -> Result<OtaInfo> {
+    let data = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read OTA info TOML: {path:?}"))?;
+    let info = toml::de::from_str(&data)
+        .with_context(|| format!("Failed to parse OTA info TOML: {path:?}"))?;
+
+    Ok(info)
+}
+
+fn write_info(path: &Path, info: &OtaInfo) -> Result<()> {
+    let data = toml::ser::to_string_pretty(info)
+        .with_context(|| format!("Failed to serialize OTA info TOML: {path:?}"))?;
+    fs::write(path, data).with_context(|| format!("Failed to write OTA info TOML: {path:?}"))?;
+
+    Ok(())
+}
+
+fn display_info(cli: &ZipCli, info: &OtaInfo) {
+    if !cli.quiet {
+        println!("{info:#?}");
+    }
+}
+
+fn load_key(group: &KeyGroup) -> Result<(RsaSigningKey, Certificate)> {
+    let source = PassphraseSource::new(
+        &group.key,
+        group.pass_file.as_deref(),
+        group.pass_env_var.as_deref(),
+    );
+    let signing_key = if let Some(helper) = &group.signing_helper {
+        let public_key = crypto::read_pem_public_key_file(&group.key)
+            .with_context(|| format!("Failed to load key: {:?}", group.key))?;
+
+        RsaSigningKey::External {
+            program: helper.clone(),
+            public_key_file: group.key.clone(),
+            public_key,
+            passphrase_source: source,
+        }
+    } else {
+        let private_key = crypto::read_pem_key_file(&group.key, &source)
+            .with_context(|| format!("Failed to load key: {:?}", group.key))?;
+
+        RsaSigningKey::Internal(private_key)
+    };
+
+    let cert = crypto::read_pem_cert_file(&group.cert)
+        .with_context(|| format!("Failed to load certificate: {:?}", group.cert))?;
+
+    Ok((signing_key, cert))
+}
+
+fn start_entry<'a>(
+    zip_writer: &'a mut ZipArchiveWriter<SigningWriter<File>>,
+    path: &str,
+    zip_mode: ZipMode,
+    is_zip64: bool,
+) -> Result<(u64, ZipDataWriter<ZipEntryWriter<'a, SigningWriter<File>>>)> {
+    let mut builder = zip_writer
+        .new_file(path)
+        .compression_method(CompressionMethod::Store);
+
+    if zip_mode == ZipMode::Seekable && is_zip64 {
+        // We need to reserve space for the ZIP64 extra field when doing the
+        // post-processing to convert a streaming zip to a seekable one.
+        builder = builder.extra_field(
+            ExtraFieldId::ANDROID_ZIP_ALIGNMENT,
+            &[0u8; 16],
+            rawzip::Header::LOCAL,
+        )?;
+    }
+
+    let (entry_writer, data_config) = builder
+        .start()
+        .with_context(|| format!("Failed to begin new zip entry: {path}"))?;
+    let offset = entry_writer.stream_offset();
+    let data_writer = data_config.wrap(entry_writer);
+
+    Ok((offset, data_writer))
+}
+
+fn finalize_entry(
+    path: &str,
+    offset: u64,
+    data_writer: ZipDataWriter<ZipEntryWriter<SigningWriter<File>>>,
+    metadata_entries: &mut Vec<ZipEntry>,
+) -> Result<()> {
+    let size = data_writer
+        .finish()
+        .and_then(|(w, d)| w.finish(d))
+        .with_context(|| format!("Failed to finalize zip entry: {path}"))?;
+
+    metadata_entries.push(ZipEntry {
+        path: path.to_owned(),
+        offset,
+        size,
+    });
+
+    Ok(())
+}
+
+fn add_otacert_entry(
+    zip_writer: &mut ZipArchiveWriter<SigningWriter<File>>,
+    zip_mode: ZipMode,
+    cert: &Certificate,
+    metadata_entries: &mut Vec<ZipEntry>,
+) -> Result<()> {
+    let (offset, mut data_writer) = start_entry(zip_writer, ota::PATH_OTACERT, zip_mode, false)?;
+
+    crypto::write_pem_cert(Path::new(ota::PATH_OTACERT), &mut data_writer, cert)
+        .with_context(|| format!("Failed to write entry: {}", ota::PATH_OTACERT))?;
+
+    finalize_entry(ota::PATH_OTACERT, offset, data_writer, metadata_entries)?;
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finalize_ota(
+    key: &RsaSigningKey,
+    cert: &Certificate,
+    mut zip_writer: ZipArchiveWriter<SigningWriter<File>>,
+    zip_mode: ZipMode,
+    metadata_entries: &mut Vec<ZipEntry>,
+    payload_metadata_size: Option<u64>,
+    metadata: &mut OtaMetadata,
+    cancel_signal: &AtomicBool,
+) -> Result<File> {
+    add_otacert_entry(&mut zip_writer, zip_mode, cert, metadata_entries)?;
+
+    let payload_metadata_size =
+        payload_metadata_size.ok_or_else(|| anyhow!("Missing payload metadata size"))?;
+    let metadata_offset = zip_writer.stream_offset();
+
+    *metadata = ota::add_metadata(
+        metadata_entries,
+        &mut zip_writer,
+        // Offset where next entry would begin.
+        metadata_offset,
+        metadata,
+        payload_metadata_size,
+    )
+    .context("Failed to write new OTA metadata")?;
+
+    let signing_writer = zip_writer
+        .finish()
+        .context("Failed to finalize output zip")?;
+    let mut raw_writer = signing_writer
+        .finish(key, cert, cancel_signal)
+        .context("Failed to sign output zip")?;
+
+    raw_writer.rewind().context("Failed to seek output zip")?;
+    ota::verify_metadata(
+        BufReader::new(&mut raw_writer),
+        metadata,
+        payload_metadata_size,
+    )
+    .context("Failed to verify OTA metadata offsets")?;
+
+    Ok(raw_writer)
+}
+
+fn unpack_subcommand(zip_cli: &ZipCli, cli: &UnpackCli, cancel_signal: &AtomicBool) -> Result<()> {
+    let (zip_reader, metadata, input_entries) = open_reader(&cli.input)?;
+
+    if !cli.no_output_files {
+        for (path, input_entry) in &input_entries {
+            let entry = zip_reader
+                .get_entry(input_entry.wayfinder)
+                .with_context(|| format!("Failed to open zip entry: {path}"))?;
+            let mut entry_reader = zip::verifying_reader(&entry, input_entry.compression_method)
+                .with_context(|| format!("Failed to open zip entry: {path}"))?;
+
+            let output_path = util::path_join(&cli.output_files, path)?;
+            let output_parent = output_path.parent().expect("No parent path");
+
+            fs::create_dir_all(output_parent)
+                .with_context(|| format!("Failed to create directory: {output_parent:?}"))?;
+
+            let mut output_file = File::create(&output_path)
+                .with_context(|| format!("Failed to open for writing: {output_path:?}"))?;
+
+            stream::copy(&mut entry_reader, &mut output_file, cancel_signal)
+                .with_context(|| format!("Failed to extract zip entry: {path}"))?;
+        }
+    }
+
+    let info = OtaInfo {
+        metadata,
+        files: input_entries.into_keys().collect(),
+    };
+
+    display_info(zip_cli, &info);
+    write_info(&cli.output_info, &info)?;
+
+    Ok(())
+}
+
+fn pack_subcommand(zip_cli: &ZipCli, cli: &PackCli, cancel_signal: &AtomicBool) -> Result<()> {
+    let (signing_key, cert) = load_key(&cli.key)?;
+    let mut info = read_info(&cli.input_info)?;
+    let mut zip_writer = open_writer(&cli.output, cli.zip_mode.zip_mode)?;
+
+    let mut input_entries = BTreeMap::new();
+
+    for path in &info.files {
+        if is_excluded_path(path) {
+            warn!("Ignoring input file: {path}");
+            continue;
+        }
+
+        let input_path = util::path_join(&cli.input_files, path)?;
+        let input_size = fs::metadata(&input_path)
+            .map(|m| m.len())
+            .with_context(|| format!("Failed to get file size: {input_path:?}"))?;
+
+        input_entries.insert(path, input_size >= 0xffffffff);
+    }
+
+    let mut payload_metadata_size = None;
+    let mut metadata_entries = vec![];
+
+    for (&path, &is_zip64) in &input_entries {
+        let (offset, mut data_writer) =
+            start_entry(&mut zip_writer, path, cli.zip_mode.zip_mode, is_zip64)?;
+
+        let input_path = util::path_join(&cli.input_files, path)?;
+        let mut input_file = File::open(&input_path)
+            .with_context(|| format!("Failed to open for reading: {input_path:?}"))?;
+
+        if path == ota::PATH_PAYLOAD {
+            let header = PayloadHeader::from_reader(&mut input_file)
+                .with_context(|| format!("Failed to read payload header: {input_path:?}"))?;
+
+            payload_metadata_size = Some(header.blob_offset);
+
+            input_file
+                .rewind()
+                .with_context(|| format!("Failed to seek file: {input_path:?}"))?;
+        }
+
+        stream::copy(&mut input_file, &mut data_writer, cancel_signal)
+            .with_context(|| format!("Failed to copy zip entry: {path}"))?;
+
+        finalize_entry(path, offset, data_writer, &mut metadata_entries)?;
+    }
+
+    finalize_ota(
+        &signing_key,
+        &cert,
+        zip_writer,
+        cli.zip_mode.zip_mode,
+        &mut metadata_entries,
+        payload_metadata_size,
+        &mut info.metadata,
+        cancel_signal,
+    )?;
+
+    drop(input_entries);
+    info.files.retain(|p| !is_excluded_path(p));
+    info.files.sort();
+
+    display_info(zip_cli, &info);
+
+    if let Some(path) = &cli.output_info {
+        write_info(path, &info)?;
+    }
+
+    Ok(())
+}
+
+fn repack_subcommand(zip_cli: &ZipCli, cli: &RepackCli, cancel_signal: &AtomicBool) -> Result<()> {
+    let (signing_key, cert) = load_key(&cli.key)?;
+    let (zip_reader, mut metadata, input_entries) = open_reader(&cli.input)?;
+    let mut zip_writer = open_writer(&cli.output, cli.zip_mode.zip_mode)?;
+
+    let mut payload_metadata_size = None;
+    let mut metadata_entries = vec![];
+
+    for (path, input_entry) in &input_entries {
+        let (offset, mut data_writer) = start_entry(
+            &mut zip_writer,
+            path,
+            cli.zip_mode.zip_mode,
+            input_entry.is_zip64,
+        )?;
+
+        let entry = zip_reader
+            .get_entry(input_entry.wayfinder)
+            .with_context(|| format!("Failed to open zip entry: {path}"))?;
+
+        if path == ota::PATH_PAYLOAD {
+            let entry_reader = zip::verifying_reader(&entry, input_entry.compression_method)
+                .with_context(|| format!("Failed to open zip entry: {path}"))?;
+
+            let header = PayloadHeader::from_reader(entry_reader)
+                .with_context(|| format!("Failed to read payload header: {path:?}"))?;
+
+            payload_metadata_size = Some(header.blob_offset);
+        }
+
+        let mut entry_reader = zip::verifying_reader(&entry, input_entry.compression_method)
+            .with_context(|| format!("Failed to open zip entry: {path}"))?;
+
+        stream::copy(&mut entry_reader, &mut data_writer, cancel_signal)
+            .with_context(|| format!("Failed to copy zip entry: {path}"))?;
+
+        finalize_entry(path, offset, data_writer, &mut metadata_entries)?;
+    }
+
+    finalize_ota(
+        &signing_key,
+        &cert,
+        zip_writer,
+        cli.zip_mode.zip_mode,
+        &mut metadata_entries,
+        payload_metadata_size,
+        &mut metadata,
+        cancel_signal,
+    )?;
+
+    let info = OtaInfo {
+        metadata,
+        files: input_entries.into_keys().collect(),
+    };
+
+    display_info(zip_cli, &info);
+
+    Ok(())
+}
+
+fn info_subcommand(zip_cli: &ZipCli, cli: &InfoCli) -> Result<()> {
+    let (_, metadata, input_entries) = open_reader(&cli.input)?;
+    let info = OtaInfo {
+        metadata,
+        files: input_entries.into_keys().collect(),
+    };
+
+    display_info(zip_cli, &info);
+
+    Ok(())
+}
+
+pub fn zip_main(cli: &ZipCli, cancel_signal: &AtomicBool) -> Result<()> {
+    match &cli.command {
+        ZipCommand::Unpack(c) => unpack_subcommand(cli, c, cancel_signal),
+        ZipCommand::Pack(c) => pack_subcommand(cli, c, cancel_signal),
+        ZipCommand::Repack(c) => repack_subcommand(cli, c, cancel_signal),
+        ZipCommand::Info(c) => info_subcommand(cli, c),
+    }
+}
+
+#[derive(Debug, Args)]
+struct KeyGroup {
+    /// Path to signing key.
+    ///
+    /// This should normally be a private key. However, if --signing-helper is
+    /// used, then it should be a public key instead.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    key: PathBuf,
+
+    /// Certificate for signing key.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    cert: PathBuf,
+
+    /// Environment variable containing private key passphrase.
+    #[arg(long, value_name = "ENV_VAR", value_parser, group = "pass")]
+    pass_env_var: Option<OsString>,
+
+    /// File containing private key passphrase.
+    #[arg(long, value_name = "FILE", value_parser, group = "pass")]
+    pass_file: Option<PathBuf>,
+
+    /// External program for signing.
+    ///
+    /// If this option is specified, then --key must refer to a public key. The
+    /// program will be invoked as:
+    ///
+    /// <program> <algo> <public key> [file <pass file>|env <pass env>]
+    #[arg(long, value_name = "PROGRAM", value_parser)]
+    signing_helper: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct ZipModeGroup {
+    /// Zip creation mode for the output OTA zip.
+    ///
+    /// The streaming mode produces zip files that contain data descriptors.
+    /// The zip file is hashed as it is being written. This mode is the default
+    /// and works with the vast majority of devices.
+    ///
+    /// The seekable mode produces zip files that do not use data descriptors.
+    /// The zip file is reread and hashed after it has been fully written. The
+    /// output file is more likely to be compatible with devices that have
+    /// broken zip file parsers.
+    #[arg(
+        long,
+        value_name = "MODE",
+        default_value_t = ZipMode::Streaming,
+    )]
+    zip_mode: ZipMode,
+}
+
+/// Unpack an OTA zip.
+#[derive(Debug, Parser)]
+struct UnpackCli {
+    /// Path to input OTA zip.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    input: PathBuf,
+
+    /// Path to output info TOML.
+    #[arg(long, value_name = "FILE", value_parser, default_value = "ota.toml")]
+    output_info: PathBuf,
+
+    /// Path to output files directory.
+    #[arg(long, value_name = "DIR", value_parser, default_value = "ota_files")]
+    output_files: PathBuf,
+
+    /// Do not output files.
+    #[arg(long, conflicts_with = "output_files")]
+    no_output_files: bool,
+}
+
+/// Pack an OTA zip.
+///
+/// The new OTA zip will *only* contain files listed in the info TOML file.
+/// Extra files in the input files directory that aren't listed will be silently
+/// ignored.
+///
+/// WARNING: This subcommand is for raw file manipulation and does not perform
+/// any validation of the contents of the payload binary. For normal usage, use
+/// `avbroot ota patch` instead.
+#[derive(Debug, Parser)]
+struct PackCli {
+    /// Path to output OTA zip.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    output: PathBuf,
+
+    /// Path to input info TOML.
+    #[arg(long, value_name = "FILE", value_parser, default_value = "ota.toml")]
+    input_info: PathBuf,
+
+    /// Path to output info TOML.
+    ///
+    /// If specified, the OTA info containing all recomputed fields will be
+    /// written to this file. This can point to the same file as --input-info.
+    #[arg(long, value_name = "FILE", value_parser)]
+    output_info: Option<PathBuf>,
+
+    /// Path to input files directory.
+    #[arg(long, value_name = "DIR", value_parser, default_value = "ota_files")]
+    input_files: PathBuf,
+
+    #[command(flatten)]
+    key: KeyGroup,
+
+    #[command(flatten)]
+    zip_mode: ZipModeGroup,
+}
+
+/// Repack an OTA zip.
+///
+/// This command is equivalent to running `unpack` and `pack`, except without
+/// storing the unpacked data to disk first.
+#[derive(Debug, Parser)]
+struct RepackCli {
+    /// Path to input OTA zip.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    input: PathBuf,
+
+    /// Path to output OTA zip.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    output: PathBuf,
+
+    #[command(flatten)]
+    key: KeyGroup,
+
+    #[command(flatten)]
+    zip_mode: ZipModeGroup,
+}
+
+/// Display OTA zip information.
+#[derive(Debug, Parser)]
+struct InfoCli {
+    /// Path to input OTA zip.
+    #[arg(short, long, value_name = "FILE", value_parser)]
+    input: PathBuf,
+}
+
+#[derive(Debug, Subcommand)]
+enum ZipCommand {
+    Unpack(UnpackCli),
+    Pack(PackCli),
+    Repack(RepackCli),
+    Info(InfoCli),
+}
+
+/// Pack, unpack, and inspect OTA zips.
+#[derive(Debug, Parser)]
+pub struct ZipCli {
+    #[command(subcommand)]
+    command: ZipCommand,
+
+    /// Don't print OTA metadata information.
+    #[arg(short, long, global = true)]
+    quiet: bool,
+}

--- a/avbroot/src/protobuf.rs
+++ b/avbroot/src/protobuf.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
 #![allow(clippy::all)]
 #![allow(clippy::nursery)]
 #![allow(clippy::pedantic)]
@@ -13,3 +16,82 @@ pub mod build {
 pub mod chromeos_update_engine {
     include!(concat!(env!("OUT_DIR"), "/chromeos_update_engine.rs"));
 }
+
+/// Implement [`serde::Serialize`] and [`serde::Deserialize`] for prost enum
+/// type and create a bridge to use with `#[serde(with = "...")]` since enum
+/// fields are stored as their underlying repr. `$type` must be a fully
+/// qualified type.
+macro_rules! serde_derive_prost_enum {
+    ($type:ty, $module:ident $(,)?) => {
+        impl serde::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.as_str_name().serialize(serializer)
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct EnumVisitor;
+
+                impl serde::de::Visitor<'_> for EnumVisitor {
+                    type Value = $type;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        write!(formatter, "a string containing a valid enum variant")
+                    }
+
+                    fn visit_str<R>(self, v: &str) -> Result<Self::Value, R>
+                    where
+                        R: serde::de::Error,
+                    {
+                        match <$type>::from_str_name(v) {
+                            Some(e) => Ok(e),
+                            None => Err(serde::de::Error::custom(format!(
+                                "invalid enum variant: {v}",
+                            ))),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_any(EnumVisitor)
+            }
+        }
+
+        mod $module {
+            pub fn serialize<S, T>(data: &T, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+                T: Copy + std::fmt::Display,
+                $type: TryFrom<T>,
+                <$type as TryFrom<T>>::Error: std::fmt::Display,
+            {
+                let value = <$type>::try_from(*data).map_err(|e| {
+                    serde::ser::Error::custom(format!("invalid enum value: {data}: {e}"))
+                })?;
+
+                serde::Serialize::serialize(&value, serializer)
+            }
+
+            pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+                T: From<$type>,
+            {
+                let value: $type = serde::Deserialize::deserialize(deserializer)?;
+
+                Ok(value.into())
+            }
+        }
+    };
+}
+
+serde_derive_prost_enum!(
+    crate::protobuf::build::tools::releasetools::ota_metadata::OtaType,
+    ota_type,
+);


### PR DESCRIPTION
This provides the last bit of machinery needed to build an OTA from scratch, outside of the usual `avbroot ota patch` mechanism. The new subcommands exist under `avbroot zip` instead of `avbroot ota` to reduce the chance of someone accidentally using them.