### PR TITLE
Add missing flush() and remove no-op flush()

### DIFF
--- a/avbroot/src/cli/avb.rs
+++ b/avbroot/src/cli/avb.rs
@@ -37,9 +37,9 @@ struct AvbInfo {
 }
 
 fn read_avb_image(path: &Path) -> Result<(AvbInfo, BufReader<File>)> {
-    let file = File::open(path)
+    let mut reader = File::open(path)
+        .map(BufReader::new)
         .with_context(|| format!("Failed to open AVB image for reading: {path:?}"))?;
-    let mut reader = BufReader::new(file);
     let (header, footer, image_size) = avb::load_image(&mut reader)
         .with_context(|| format!("Failed to load AVB image: {path:?}"))?;
 
@@ -101,14 +101,14 @@ fn write_raw(
     size: u64,
     cancel_signal: &AtomicBool,
 ) -> Result<File> {
-    let file = fs::OpenOptions::new()
+    let mut writer = fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(true)
         .open(path)
+        .map(BufWriter::new)
         .with_context(|| format!("Failed to open raw image for writing: {path:?}"))?;
-    let mut writer = BufWriter::new(file);
 
     reader
         .rewind()

--- a/avbroot/src/cli/cpio.rs
+++ b/avbroot/src/cli/cpio.rs
@@ -36,9 +36,10 @@ fn open_reader(
     CpioReader<CompressedReader<BufReader<File>>>,
     CompressedFormat,
 )> {
-    let file =
-        File::open(path).with_context(|| format!("Failed to open cpio for reading: {path:?}"))?;
-    let reader = CompressedReader::new(BufReader::new(file), true)
+    let raw_reader = File::open(path)
+        .map(BufReader::new)
+        .with_context(|| format!("Failed to open cpio for reading: {path:?}"))?;
+    let reader = CompressedReader::new(raw_reader, true)
         .with_context(|| format!("Failed to open decompressor: {path:?}"))?;
     let format = reader.format();
     let cpio_reader = CpioReader::new(reader, include_trailer);
@@ -50,9 +51,10 @@ fn open_writer(
     path: &Path,
     format: CompressedFormat,
 ) -> Result<CpioWriter<CompressedWriter<BufWriter<File>>>> {
-    let file =
-        File::create(path).with_context(|| format!("Failed to open cpio for writing: {path:?}"))?;
-    let writer = CompressedWriter::new(BufWriter::new(file), format)
+    let raw_writer = File::create(path)
+        .map(BufWriter::new)
+        .with_context(|| format!("Failed to open cpio for writing: {path:?}"))?;
+    let writer = CompressedWriter::new(raw_writer, format)
         .with_context(|| format!("Failed to open compressor: {path:?}"))?;
     let cpio_writer = CpioWriter::new(writer, false);
 

--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -1600,7 +1600,6 @@ pub fn patch_subcommand(cli: &PatchCli, cancel_signal: &AtomicBool) -> Result<()
     let mut temp_writer = signing_writer
         .finish(&key_ota, &cert_ota, cancel_signal)
         .context("Failed to sign output zip")?;
-    temp_writer.flush().context("Failed to flush output zip")?;
 
     // We do a lot of low-level hackery. Reopen and verify offsets.
     info!("Verifying metadata offsets");

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -235,9 +235,11 @@ fn pack_subcommand(
             .with_context(|| format!("Failed to copy from replacement image: {name}"))?;
     }
 
-    let (_, header, properties, _) = payload_writer
+    let (raw_writer, header, properties, _) = payload_writer
         .finish()
         .context("Failed to finalize payload")?;
+
+    raw_writer.into_inner().context("Failed to flush payload")?;
 
     // Display the header information now that it has been finalized.
     display_header(payload_cli, &header);

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -68,11 +68,11 @@ use crate::{
 fn hash_file(path: &Path, cancel_signal: &AtomicBool) -> Result<[u8; 32]> {
     info!("Calculating hash: {path:?}");
 
-    let raw_reader =
-        File::open(path).with_context(|| format!("Failed to open for reading: {path:?}"))?;
-    let buf_reader = BufReader::new(raw_reader);
+    let raw_reader = File::open(path)
+        .map(BufReader::new)
+        .with_context(|| format!("Failed to open for reading: {path:?}"))?;
     let context = ring::digest::Context::new(&ring::digest::SHA256);
-    let mut hashing_reader = HashingReader::new(buf_reader, context);
+    let mut hashing_reader = HashingReader::new(raw_reader, context);
 
     stream::copy(&mut hashing_reader, io::sink(), cancel_signal)?;
 


### PR DESCRIPTION
* `flush()` or `into_inner()` is now called for all `BufWriter`s
* `flush()` is no longer called for `File`s, which is a no-op operation