### PR TITLE
Add option to re-sign unmodified partitions during patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,10 @@ The only behavior this changes is where the partition is read from. When using `
 
 This has no impact on what patches are applied. For example, when using Magisk, the root patch is applied to the boot partition, no matter if the partition came from the original `payload.bin` or from `--replace`.
 
+### Re-signing partitions
+
+avbroot will automatically re-sign any partitions in the OTA that it modifies. However, partitions that are otherwise unmodified can also be re-signed with `--re-sign <partition name>`. This is useful, for example, when the OTA contains partitions signed with the public AOSP test key.
+
 ### Booting signed GSIs
 
 Android's [Dynamic System Updates (DSU)](https://developer.android.com/topic/dsu) feature uses a different root of trust than the regular system. Instead of using the bootloader's `avb_custom_key`, it obtains the trusted keys from the `first_stage_ramdisk/avb/*.avbpubkey` files inside the `init_boot` or `vendor_boot` ramdisk. These files are encoded in the same binary format as `avb_pkmd.bin`.

--- a/e2e/e2e.toml
+++ b/e2e/e2e.toml
@@ -53,11 +53,11 @@ data.ramdisks = [["otacerts", "first_stage", "dsu_key_dir"]]
 
 [profile.pixel_v4_gki.hashes_streaming]
 original = "ea96196191e3a4133db4aff45d47aa3468514e29e0a724faac8081cbf4adf808"
-patched = "179923431ff94148186d8b0a457636c8a60057d047d55a4fc4da3a162e73eeed"
+patched = "c073cbb271099aaf338a8c70f3565ec70db47a87b4c9bb3efffd96ccee1a0c27"
 
 [profile.pixel_v4_gki.hashes_seekable]
 original = "f6615ae355eba38689d24aa535981d09175d4832e7c65c04cdd89aa95d21f09d"
-patched = "b006858b78cddef0e3db1d77454cd945111ce15708121e3a483ff711abedec8b"
+patched = "65ce91a95574a308ffc5279696efe7f6f7e4e847795dc9ae43d9ffd012a7ce3f"
 
 # Google Pixel 6a
 # What's unique: boot (boot v4, no ramdisk) + vendor_boot (vendor v4, 2 ramdisks)

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
 // SPDX-FileCopyrightText: 2023 Pascal Roeleven
 // SPDX-License-Identifier: GPL-3.0-only
 
@@ -1067,6 +1067,8 @@ fn patch_image(
         OsStr::new("--replace"),
         OsStr::new("system"),
         system_image_file.as_os_str(),
+        OsStr::new("--re-sign"),
+        OsStr::new("boot"),
         OsStr::new("--key-avb"),
         avb_key_file.as_os_str(),
         OsStr::new("--pass-avb-file"),


### PR DESCRIPTION
This is useful when the OTA contains partition images that are signed with the AOSP test keys.

Issue: #569