### PR TITLE
cli/payload: Skip recow for non-VABC payloads when packing

### DIFF
--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -219,8 +219,11 @@ pub fn pack_payload(
 
     for (name, input_file) in &input_files {
         let Some(dpm) = &header.manifest.dynamic_partition_metadata else {
-            continue;
+            break;
         };
+        if !dpm.vabc_enabled() {
+            break;
+        }
 
         if !dpm.groups.iter().any(|g| g.partition_names.contains(name)) {
             continue;


### PR DESCRIPTION
Setting the CoW size for non-VABC payloads is invalid and results in the recow process failing with:

    ERROR Partition has CoW estimate, but VABC is disabled: <name>

Fixes: #607