### PR TITLE
fix: only compress regular files during Magisk backup

### DIFF
--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -32,7 +32,7 @@ use crate::{
         avb::{self, AppendedDescriptorMut, Footer, Header},
         bootimage::{self, BootImage, BootImageExt, RamdiskMeta},
         compression::{self, CompressedFormat, CompressedReader, CompressedWriter},
-        cpio::{self, CpioEntry, CpioEntryData},
+        cpio::{self, CpioEntry, CpioEntryData, CpioEntryType},
         zip::{self, ZipEntriesSafeExt, ZipFileHeaderRecordExt, ZipSliceEntriesSafeExt},
     },
     patch::otacert::{self, OtaCertBuildFlags},
@@ -407,7 +407,10 @@ impl MagiskRootPatcher {
             let mut new_path = b".backup/".to_vec();
             new_path.extend(&old_entry.path);
 
-            let new_data = if xz_compress && let CpioEntryData::Data(data) = &old_entry.data {
+            let new_data = if xz_compress
+                && old_entry.file_type == CpioEntryType::Regular
+                && let CpioEntryData::Data(data) = &old_entry.data
+            {
                 new_path.extend(b".xz");
 
                 let reader = Cursor::new(data);


### PR DESCRIPTION
Creation of Magisk .backup/ files should only xz-compress real files, and ignore other types such as symlinks. This fixes the case where /init is a symlink, and avbroot incorrectly puts the backup symlink at .backup/init.xz with the target path being compressed binary data.

Fixes: #610