### PR TITLE
Update rawzip to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "rawzip"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9575f44c8cf85bc843ad666dcdf20d05a7753772bef56eb2a5140282b32150"
+checksum = "d661184e2add3106911b7c17e76b49328db021428c242ce0e577c3e8744d8130"
 
 [[package]]
 name = "rayon"

--- a/avbroot/Cargo.toml
+++ b/avbroot/Cargo.toml
@@ -39,7 +39,7 @@ pkcs8 = { version = "0.10.2", features = ["encryption", "pem"] }
 prost = "0.14.1"
 # We can't upgrade to 0.9.0 until rsa updates its rand_core dependency.
 rand = "0.8.5"
-rawzip = "0.4.0"
+rawzip = "0.5.0"
 rayon = "1.7.0"
 regex = { version = "1.9.4", default-features = false, features = ["perf", "std"] }
 # We use ring instead of sha2 for sha256 digest computation of large files

--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -17,8 +17,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use bitflags::bitflags;
 use clap::{ArgAction, Args, Parser, Subcommand, value_parser};
 use rawzip::{
-    CompressionMethod, RECOMMENDED_BUFFER_SIZE, ZipArchive, ZipArchiveEntryWayfinder,
-    ZipArchiveWriter, extra_fields::ExtraFieldId,
+    CompressionMethod, Crc32Option, DataDescriptorOutput, RECOMMENDED_BUFFER_SIZE, ZipArchive,
+    ZipArchiveEntryWayfinder, ZipArchiveWriter, extra_fields::ExtraFieldId,
 };
 use rayon::{iter::IntoParallelRefIterator, prelude::ParallelIterator};
 use tempfile::{NamedTempFile, TempDir};
@@ -1254,7 +1254,7 @@ fn patch_ota_zip(
 ) -> Result<(OtaMetadata, u64)> {
     struct InputEntry {
         compression_method: CompressionMethod,
-        is_zip64: bool,
+        crc32: u32,
         // We can't store the rawzip::ZipEntry directly because of the lifetime
         // generic parameter. We'll need to read the local headers again later.
         wayfinder: ZipArchiveEntryWayfinder,
@@ -1281,11 +1281,7 @@ fn patch_ota_zip(
             path.to_owned(),
             InputEntry {
                 compression_method: cd_entry.compression_method(),
-                // We only check for the sizes here instead of the presence of
-                // the ZIP64 extra field. The central header's extra fields may
-                // have ZIP64 only for the local header offset.
-                is_zip64: cd_entry.compressed_size_hint() >= 0xffffffff
-                    || cd_entry.uncompressed_size_hint() >= 0xffffffff,
+                crc32: cd_entry.crc32(),
                 wayfinder: cd_entry.wayfinder(),
             },
         );
@@ -1310,6 +1306,19 @@ fn patch_ota_zip(
 
     for (path, input_entry) in &input_entries {
         let _span = debug_span!("zip", entry = path).entered();
+
+        // Paths we don't care about can be copied without recompression.
+        let raw_copy = path != ota::PATH_METADATA
+            && path != ota::PATH_METADATA_PB
+            && path != ota::PATH_OTACERT
+            && path != ota::PATH_PAYLOAD
+            && path != ota::PATH_PROPERTIES;
+
+        // We only check for the sizes here instead of the presence of the ZIP64
+        // extra field. The central header's extra fields may have ZIP64 only
+        // for the local header offset.
+        let is_zip64 = input_entry.wayfinder.compressed_size_hint() >= 0xffffffff
+            || input_entry.wayfinder.uncompressed_size_hint() >= 0xffffffff;
 
         let entry = zip_reader
             .get_entry(input_entry.wayfinder)
@@ -1360,7 +1369,7 @@ fn patch_ota_zip(
             .new_file(path)
             .compression_method(input_entry.compression_method);
 
-        if zip_mode == ZipMode::Seekable && input_entry.is_zip64 {
+        if zip_mode == ZipMode::Seekable && is_zip64 {
             // We need to reserve space for the ZIP64 extra field when doing the
             // post-processing to convert a streaming zip to a seekable one.
             builder = builder.extra_field(
@@ -1370,13 +1379,23 @@ fn patch_ota_zip(
             )?;
         }
 
+        // For simplicity, we still use the same types when writing the output.
+        // We'll just skip the invalid CRC32 calculation (on compressed data)
+        // and avoid double compression.
+        let write_compression_method: CompressionMethod;
+        if raw_copy {
+            builder = builder.crc32(Crc32Option::Skip);
+            write_compression_method = CompressionMethod::STORE;
+        } else {
+            write_compression_method = input_entry.compression_method;
+        }
+
         let (entry_writer, data_config) = builder
             .start()
             .with_context(|| format!("Failed to begin new zip entry: {path}"))?;
         let offset = entry_writer.stream_offset();
-        let compressed_writer =
-            zip::compressed_writer(entry_writer, input_entry.compression_method)
-                .with_context(|| format!("Failed to begin new zip entry: {path}"))?;
+        let compressed_writer = zip::compressed_writer(entry_writer, write_compression_method)
+            .with_context(|| format!("Failed to begin new zip entry: {path}"))?;
         let mut data_writer = data_config.wrap(compressed_writer);
 
         // All remaining entries are written immediately.
@@ -1391,7 +1410,7 @@ fn patch_ota_zip(
             ota::PATH_PAYLOAD => {
                 info!("Patching zip entry: {path}");
 
-                if input_entry.compression_method != CompressionMethod::Store {
+                if input_entry.compression_method != CompressionMethod::STORE {
                     bail!("{path} is not stored uncompressed");
                 }
 
@@ -1434,20 +1453,31 @@ fn patch_ota_zip(
             _ => {
                 info!("Copying zip entry: {path}");
 
-                stream::copy(&mut reader, &mut data_writer, cancel_signal)
+                drop(reader);
+
+                stream::copy(&mut entry.reader(), &mut data_writer, cancel_signal)
                     .with_context(|| format!("Failed to copy zip entry: {path}"))?;
             }
         }
 
-        let size = data_writer
+        let written = data_writer
             .finish()
-            .and_then(|(w, d)| w.finish()?.finish(d))
+            .and_then(|(w, mut d)| {
+                if raw_copy {
+                    d = DataDescriptorOutput::new(
+                        input_entry.crc32,
+                        input_entry.wayfinder.uncompressed_size_hint(),
+                    );
+                }
+
+                w.finish()?.finish(d)
+            })
             .with_context(|| format!("Failed to finalize zip entry: {path}"))?;
 
         metadata_entries.push(ZipEntry {
             path: path.clone(),
             offset,
-            size,
+            size: written.compressed_size(),
         });
     }
 
@@ -2262,9 +2292,7 @@ pub fn list_subcommand(cli: &ListCli) -> Result<()> {
         .with_context(|| format!("Failed to read zip: {:?}", cli.input))?;
     let mut entries = zip.entries_safe(&mut buffer);
 
-    while let Some((cd_entry, _)) =
-        entries.next_entry().context("Failed to list zip entries")?
-    {
+    while let Some((cd_entry, _)) = entries.next_entry().context("Failed to list zip entries")? {
         let path = cd_entry
             .file_path_utf8()
             .context("Zip contains non-UTF-8 paths")?;
@@ -2666,7 +2694,6 @@ pub struct ListCli {
     #[arg(short, long, value_name = "FILE", value_parser)]
     pub input: PathBuf,
 }
-
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]

--- a/avbroot/src/cli/zip.rs
+++ b/avbroot/src/cli/zip.rs
@@ -181,7 +181,7 @@ fn start_entry<'a>(
 ) -> Result<(u64, ZipDataWriter<ZipEntryWriter<'a, SigningWriter<File>>>)> {
     let mut builder = zip_writer
         .new_file(path)
-        .compression_method(CompressionMethod::Store);
+        .compression_method(CompressionMethod::STORE);
 
     if zip_mode == ZipMode::Seekable && is_zip64 {
         // We need to reserve space for the ZIP64 extra field when doing the
@@ -208,7 +208,7 @@ fn finalize_entry(
     data_writer: ZipDataWriter<ZipEntryWriter<SigningWriter<File>>>,
     metadata_entries: &mut Vec<ZipEntry>,
 ) -> Result<()> {
-    let size = data_writer
+    let written = data_writer
         .finish()
         .and_then(|(w, d)| w.finish(d))
         .with_context(|| format!("Failed to finalize zip entry: {path}"))?;
@@ -216,7 +216,7 @@ fn finalize_entry(
     metadata_entries.push(ZipEntry {
         path: path.to_owned(),
         offset,
-        size,
+        size: written.compressed_size(),
     });
 
     Ok(())

--- a/avbroot/src/format/ota.rs
+++ b/avbroot/src/format/ota.rs
@@ -519,12 +519,12 @@ pub fn add_metadata(
             .write_all(data)
             .map_err(|e| Error::ZipEntryWrite(path.into(), e))?;
 
-        let data_size = data_writer
+        let written = data_writer
             .finish()
             .and_then(|(w, d)| w.finish(d))
             .map_err(|e| Error::ZipEntryFinish(path.into(), e))?;
 
-        Ok((data_offset, data_size))
+        Ok((data_offset, written.compressed_size()))
     }
 
     let mut metadata = metadata.clone();
@@ -602,7 +602,7 @@ pub fn verify_metadata(
     let mut entries = archive.entries_safe(&mut buffer);
 
     while let Some((cd_entry, entry)) = entries.next_entry().map_err(Error::ZipEntryList)? {
-        if cd_entry.compression_method() != CompressionMethod::Store {
+        if cd_entry.compression_method() != CompressionMethod::STORE {
             continue;
         }
 

--- a/avbroot/src/format/zip.rs
+++ b/avbroot/src/format/zip.rs
@@ -234,8 +234,8 @@ fn compression_method_to_format(
     compression_method: CompressionMethod,
 ) -> Result<CompressedFormat, rawzip::Error> {
     match compression_method {
-        CompressionMethod::Store => Ok(CompressedFormat::None),
-        CompressionMethod::Deflate => Ok(CompressedFormat::Deflate),
+        CompressionMethod::STORE => Ok(CompressedFormat::None),
+        CompressionMethod::DEFLATE => Ok(CompressedFormat::Deflate),
         c => Err(rawzip::ErrorKind::InvalidInput {
             msg: format!("Unsupported compression method: {c:?}"),
         }
@@ -267,7 +267,7 @@ pub fn compressed_slice_reader<'archive>(
 pub fn verifying_reader<'archive, R: ReaderAt>(
     entry: &ZipEntry<'archive, R>,
     compression_method: CompressionMethod,
-) -> Result<ZipVerifier<CompressedReader<ZipReader<&'archive R>>, &'archive R>, rawzip::Error> {
+) -> Result<ZipVerifier<CompressedReader<ZipReader<&'archive R>>>, rawzip::Error> {
     compressed_reader(entry, compression_method).map(|r| entry.verifying_reader(r))
 }
 

--- a/avbroot/src/patch/otacert.rs
+++ b/avbroot/src/patch/otacert.rs
@@ -77,9 +77,9 @@ pub fn create_zip(cert: &Certificate, flags: OtaCertBuildFlags) -> Result<Vec<u8
     let mut writer = ZipArchiveWriter::new(raw_writer);
 
     let compression_method = if flags.contains(OtaCertBuildFlags::COMPRESS_DEFLATE) {
-        CompressionMethod::Deflate
+        CompressionMethod::DEFLATE
     } else {
-        CompressionMethod::Store
+        CompressionMethod::STORE
     };
 
     let name = "ota.x509.pem";

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -15,7 +15,7 @@ avbroot = { path = "../avbroot" }
 clap = { version = "4.4.1", features = ["derive"] }
 ctrlc = "3.4.0"
 hex = { version = "0.4.3", features = ["serde"] }
-rawzip = "0.4.0"
+rawzip = "0.5.0"
 ring = "0.17.14"
 rsa = { version = "0.9.6", features = ["hazmat"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -786,7 +786,7 @@ fn create_ota(
             _ => unreachable!(),
         }
 
-        let size = data_writer
+        let written = data_writer
             .finish()
             .and_then(|(w, d)| w.finish(d))
             .with_context(|| format!("Failed to finalize zip entry: {path}"))?;
@@ -794,7 +794,7 @@ fn create_ota(
         entries.push(ZipEntry {
             path: path.to_owned(),
             offset,
-            size,
+            size: written.compressed_size(),
         });
     }
 
@@ -859,7 +859,7 @@ fn create_fake_magisk(output: &Path) -> Result<()> {
         .open(output)
         .with_context(|| format!("Failed to open for writing: {output:?}"))?;
     let mut zip_writer = ZipArchiveWriter::new(raw_writer);
-    let compression_method = CompressionMethod::Deflate;
+    let compression_method = CompressionMethod::DEFLATE;
 
     for path in [
         "assets/stub.apk",


### PR DESCRIPTION
This new version allows writing a custom data descriptor, which we can use to do raw copies for zip entries we do not care about, skipping the unnecessary decompression + recompression.