### PR TITLE
Update rawzip to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,9 +1474,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rawzip"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661184e2add3106911b7c17e76b49328db021428c242ce0e577c3e8744d8130"
+checksum = "75a2b2577f5fd7e26caabd4aa7bba1ef18653ff32204eea251c1136db1a549f3"
 
 [[package]]
 name = "rayon"


### PR DESCRIPTION
Fixes parsing OTA zips that contain a zip64 EOCD and EOCD locator before the non-zip64 EOCD, and the non-zip64 EOCD does not indicate that the zip64 parts are present.