### PR TITLE
Add support for non-deterministic signing

### DIFF
--- a/avbroot/src/cli/avb.rs
+++ b/avbroot/src/cli/avb.rs
@@ -19,7 +19,7 @@ use sha2::{Digest, Sha256};
 use tracing::{Span, debug_span, info, warn};
 
 use crate::{
-    crypto::{self, PassphraseSource, SigningPrivateKey, SigningPublicKey},
+    crypto::{self, PassphraseSource, SigningMethod, SigningPrivateKey, SigningPublicKey},
     format::avb::{
         self, AlgorithmType, AppendedDescriptorMut, AppendedDescriptorRef, Descriptor, Footer,
         HashTreeDescriptor, Header, KernelCmdlineDescriptor,
@@ -442,7 +442,7 @@ fn sign_or_clear(info: &mut AvbInfo, orig_header: &Header, key_group: &KeyGroup)
                 .set_algo_for_key(&signing_key)
                 .context("Failed to set signature algorithm")?;
             info.header
-                .sign(&signing_key)
+                .sign(&signing_key, key_group.signing_method)
                 .context("Failed to sign new AVB header")?;
         }
         SignAction::Clear => {
@@ -1058,6 +1058,21 @@ struct KeyGroup {
     /// <program> <algo> <public key> [file <pass file>|env <pass env>]
     #[arg(long, value_name = "PROGRAM", value_parser)]
     signing_helper: Option<PathBuf>,
+
+    /// Preferred signing method.
+    ///
+    /// Defaults to deterministic signatures. If the non-deterministic mode is
+    /// selected, but is not supported for a signing operation, then it will
+    /// fall back to deterministic signatures.
+    ///
+    /// For RSA, non-deterministic signatures are never supported because
+    /// Android uses the PKCS#1 v1.5 scheme.
+    ///
+    /// For ML-DSA, non-deterministic signatures use the hedged variant. This
+    /// can help reduce the impact of broken RNGs and side channel attacks at
+    /// the expense of the output no longer being byte-for-byte reproducible.
+    #[arg(long, default_value_t, conflicts_with = "signing_helper")]
+    signing_method: SigningMethod,
 }
 
 /// Unpack an AVB image.

--- a/avbroot/src/cli/ota.rs
+++ b/avbroot/src/cli/ota.rs
@@ -31,7 +31,7 @@ use crate::{
         self,
         avb::{ImageOpener, TrustMethod},
     },
-    crypto::{self, PassphraseSource, SigningPrivateKey},
+    crypto::{self, PassphraseSource, SigningMethod, SigningPrivateKey},
     format::{
         avb::{self, Descriptor, Header},
         ota::{self, SigningWriter, ZipEntry, ZipMode},
@@ -231,6 +231,7 @@ fn patch_boot_images(
     input_files: &mut HashMap<String, InputFile>,
     boot_patchers: &[Box<dyn BootImagePatch + Sync>],
     key_avb: &SigningPrivateKey,
+    method: SigningMethod,
     cancel_signal: &AtomicBool,
 ) -> Result<()> {
     let boot_partitions = required_images
@@ -265,6 +266,7 @@ fn patch_boot_images(
         &boot_partitions,
         &Opener(Mutex::new(input_files)),
         key_avb,
+        method,
         boot_patchers,
         cancel_signal,
     )
@@ -285,6 +287,7 @@ fn patch_system_image<'a>(
     input_files: &mut HashMap<String, InputFile>,
     cert_ota: &Certificate,
     key_avb: &SigningPrivateKey,
+    method: SigningMethod,
     cancel_signal: &AtomicBool,
 ) -> Result<(&'a str, Vec<Range<u64>>)> {
     let mut system_iter = required_images
@@ -317,7 +320,7 @@ fn patch_system_image<'a>(
     }
 
     let (mut ranges, other_ranges) =
-        system::patch_system_image(&input_file.file, cert_ota, key_avb, cancel_signal)
+        system::patch_system_image(&input_file.file, cert_ota, key_avb, method, cancel_signal)
             .with_context(|| format!("Failed to patch system image: {target}"))?;
 
     input_file.state = InputFileState::Modified;
@@ -337,6 +340,7 @@ fn re_sign_unmodified_images(
     re_sign_images: &HashSet<String>,
     input_files: &mut HashMap<String, InputFile>,
     key_avb: &SigningPrivateKey,
+    method: SigningMethod,
     block_size: u64,
     cancel_signal: &AtomicBool,
 ) -> Result<()> {
@@ -364,7 +368,7 @@ fn re_sign_unmodified_images(
                     .set_algo_for_key(key_avb)
                     .with_context(|| format!("Failed to set signature algorithm: {name}"))?;
                 header
-                    .sign(key_avb)
+                    .sign(key_avb, method)
                     .with_context(|| format!("Failed to sign AVB metadata: {name}"))?;
             }
 
@@ -786,6 +790,7 @@ fn update_vbmeta_headers(
     order: &mut [(String, HashSet<String>)],
     clear_vbmeta_flags: bool,
     key: &SigningPrivateKey,
+    method: SigningMethod,
     block_size: u64,
 ) -> Result<()> {
     info!(
@@ -830,7 +835,7 @@ fn update_vbmeta_headers(
                 .set_algo_for_key(key)
                 .with_context(|| format!("Failed to set signature algorithm: {name}"))?;
             parent_header
-                .sign(key)
+                .sign(key, method)
                 .with_context(|| format!("Failed to sign vbmeta header for image: {name}"))?;
 
             let mut writer = tempfile::tempfile()
@@ -1013,6 +1018,7 @@ fn patch_ota_payload(
     key_avb: &SigningPrivateKey,
     key_ota: &SigningPrivateKey,
     cert_ota: &Certificate,
+    method: SigningMethod,
     cancel_signal: &AtomicBool,
 ) -> Result<(String, u64)> {
     let mut header = PayloadHeader::from_reader(UserPosFile::new(payload))
@@ -1083,6 +1089,7 @@ fn patch_ota_payload(
         &mut input_files,
         boot_patchers,
         key_avb,
+        method,
         cancel_signal,
     )?;
 
@@ -1094,6 +1101,7 @@ fn patch_ota_payload(
             &mut input_files,
             cert_ota,
             key_avb,
+            method,
             cancel_signal,
         )?)
     };
@@ -1102,6 +1110,7 @@ fn patch_ota_payload(
         re_sign_images,
         &mut input_files,
         key_avb,
+        method,
         header.manifest.block_size().into(),
         cancel_signal,
     )?;
@@ -1118,6 +1127,7 @@ fn patch_ota_payload(
         &mut vbmeta_order,
         clear_vbmeta_flags,
         key_avb,
+        method,
         header.manifest.block_size().into(),
     )?;
 
@@ -1164,7 +1174,7 @@ fn patch_ota_payload(
 
     info!("Generating new OTA payload");
 
-    let mut payload_writer = PayloadWriter::new(writer, header.clone(), key_ota.clone())
+    let mut payload_writer = PayloadWriter::new(writer, header.clone(), key_ota.clone(), method)
         .context("Failed to write payload header")?;
     let mut orig_payload_reader = UserPosFile::new(payload);
 
@@ -1250,6 +1260,7 @@ fn patch_ota_zip(
     key_avb: &SigningPrivateKey,
     key_ota: &SigningPrivateKey,
     cert_ota: &Certificate,
+    method: SigningMethod,
     cancel_signal: &AtomicBool,
 ) -> Result<(OtaMetadata, u64)> {
     struct InputEntry {
@@ -1434,6 +1445,7 @@ fn patch_ota_zip(
                     key_avb,
                     key_ota,
                     cert_ota,
+                    method,
                     cancel_signal,
                 )
                 .with_context(|| format!("Failed to patch payload: {path}"))?;
@@ -1733,6 +1745,7 @@ pub fn patch_subcommand(cli: &PatchCli, cancel_signal: &AtomicBool) -> Result<()
         &key_avb,
         &key_ota,
         &cert_ota,
+        cli.signing_method,
         cancel_signal,
     )
     .context("Failed to patch OTA zip")?;
@@ -1741,7 +1754,7 @@ pub fn patch_subcommand(cli: &PatchCli, cancel_signal: &AtomicBool) -> Result<()
         .finish()
         .context("Failed to finalize output zip")?;
     let mut temp_writer = signing_writer
-        .finish(&key_ota, &cert_ota, cancel_signal)
+        .finish(&key_ota, &cert_ota, cli.signing_method, cancel_signal)
         .context("Failed to sign output zip")?;
 
     // We do a lot of low-level hackery. Reopen and verify offsets.
@@ -2453,6 +2466,21 @@ pub struct PatchCli {
     /// <program> <algo> <public key> [file <pass file>|env <pass env>]
     #[arg(long, value_name = "PROGRAM", value_parser, help_heading = HEADING_KEY)]
     pub signing_helper: Option<PathBuf>,
+
+    /// Preferred signing method.
+    ///
+    /// Defaults to deterministic signatures. If the non-deterministic mode is
+    /// selected, but is not supported for a signing operation, then it will
+    /// fall back to deterministic signatures.
+    ///
+    /// For RSA, non-deterministic signatures are never supported because
+    /// Android uses the PKCS#1 v1.5 scheme.
+    ///
+    /// For ML-DSA, non-deterministic signatures use the hedged variant. This
+    /// can help reduce the impact of broken RNGs and side channel attacks at
+    /// the expense of the output no longer being byte-for-byte reproducible.
+    #[arg(long, default_value_t, conflicts_with = "signing_helper")]
+    signing_method: SigningMethod,
 
     /// Use partition image from a file instead of the original payload.
     #[arg(

--- a/avbroot/src/cli/payload.rs
+++ b/avbroot/src/cli/payload.rs
@@ -16,7 +16,7 @@ use tracing::info;
 
 use crate::{
     cli::ota,
-    crypto::{self, PassphraseSource, SigningPrivateKey},
+    crypto::{self, PassphraseSource, SigningMethod, SigningPrivateKey},
     format::payload::{PayloadHeader, PayloadWriter},
     stream::{self, FromReader, SectionReader},
     util,
@@ -44,9 +44,10 @@ fn open_writer(
     path: &Path,
     header: PayloadHeader,
     key: SigningPrivateKey,
+    method: SigningMethod,
 ) -> Result<PayloadWriter<BufWriter<File>>> {
     let writer = open_raw_writer(path)?;
-    let payload_writer = PayloadWriter::new(writer, header, key)
+    let payload_writer = PayloadWriter::new(writer, header, key, method)
         .with_context(|| format!("Failed to write payload header: {path:?}"))?;
 
     Ok(payload_writer)
@@ -76,7 +77,7 @@ fn display_header(quiet: bool, header: &PayloadHeader) {
     }
 }
 
-fn load_key(group: &KeyGroup) -> Result<SigningPrivateKey> {
+fn load_key(group: &KeyGroup) -> Result<(SigningPrivateKey, SigningMethod)> {
     let source = PassphraseSource::new(
         &group.key,
         group.pass_file.as_deref(),
@@ -97,7 +98,7 @@ fn load_key(group: &KeyGroup) -> Result<SigningPrivateKey> {
             .with_context(|| format!("Failed to load key: {:?}", group.key))?
     };
 
-    Ok(signing_key)
+    Ok((signing_key, group.signing_method))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -196,6 +197,7 @@ pub fn pack_payload(
     input_images: &Path,
     writer: &mut dyn Write,
     signing_key: &SigningPrivateKey,
+    method: SigningMethod,
     cancel_signal: &AtomicBool,
 ) -> Result<(String, u64)> {
     let mut header = read_info(input_info)?;
@@ -255,8 +257,9 @@ pub fn pack_payload(
 
     // Now we can write the actual payload. With everything precomputed, this is
     // mostly just a simple copy.
-    let mut payload_writer = PayloadWriter::new(writer, header.clone(), signing_key.clone())
-        .context("Failed to write payload header")?;
+    let mut payload_writer =
+        PayloadWriter::new(writer, header.clone(), signing_key.clone(), method)
+            .context("Failed to write payload header")?;
 
     while payload_writer
         .begin_next_operation()
@@ -307,7 +310,7 @@ fn pack_subcommand(
     cli: &PackCli,
     cancel_signal: &AtomicBool,
 ) -> Result<()> {
-    let signing_key = load_key(&cli.key)?;
+    let (signing_key, method) = load_key(&cli.key)?;
 
     let mut writer = open_raw_writer(&cli.output)?;
 
@@ -317,6 +320,7 @@ fn pack_subcommand(
         &cli.input_images,
         &mut writer,
         &signing_key,
+        method,
         cancel_signal,
     )?;
 
@@ -336,13 +340,13 @@ fn repack_subcommand(
     cli: &RepackCli,
     cancel_signal: &AtomicBool,
 ) -> Result<()> {
-    let signing_key = load_key(&cli.key)?;
+    let (signing_key, method) = load_key(&cli.key)?;
 
     let (mut reader, header) = open_reader(&cli.input)?;
 
     info!("Generating new OTA payload");
 
-    let mut payload_writer = open_writer(&cli.output, header.clone(), signing_key)?;
+    let mut payload_writer = open_writer(&cli.output, header.clone(), signing_key, method)?;
 
     while payload_writer
         .begin_next_operation()
@@ -435,6 +439,21 @@ struct KeyGroup {
     /// <program> <algo> <public key> [file <pass file>|env <pass env>]
     #[arg(long, value_name = "PROGRAM", value_parser)]
     signing_helper: Option<PathBuf>,
+
+    /// Preferred signing method.
+    ///
+    /// Defaults to deterministic signatures. If the non-deterministic mode is
+    /// selected, but is not supported for a signing operation, then it will
+    /// fall back to deterministic signatures.
+    ///
+    /// For RSA, non-deterministic signatures are never supported because
+    /// Android uses the PKCS#1 v1.5 scheme.
+    ///
+    /// For ML-DSA, non-deterministic signatures use the hedged variant. This
+    /// can help reduce the impact of broken RNGs and side channel attacks at
+    /// the expense of the output no longer being byte-for-byte reproducible.
+    #[arg(long, default_value_t, conflicts_with = "signing_helper")]
+    signing_method: SigningMethod,
 }
 
 /// Unpack a payload binary.

--- a/avbroot/src/cli/zip.rs
+++ b/avbroot/src/cli/zip.rs
@@ -22,7 +22,7 @@ use x509_cert::Certificate;
 
 use crate::{
     cli::payload,
-    crypto::{self, PassphraseSource, SigningPrivateKey},
+    crypto::{self, PassphraseSource, SigningMethod, SigningPrivateKey},
     format::{
         ota::{self, SigningWriter, ZipEntry, ZipMode},
         payload::PayloadHeader,
@@ -144,7 +144,7 @@ fn display_info(quiet: bool, info: &OtaInfo) {
     }
 }
 
-fn load_key(group: &KeyGroup) -> Result<(SigningPrivateKey, Certificate)> {
+fn load_key(group: &KeyGroup) -> Result<(SigningPrivateKey, Certificate, SigningMethod)> {
     let source = PassphraseSource::new(
         &group.key,
         group.pass_file.as_deref(),
@@ -168,7 +168,7 @@ fn load_key(group: &KeyGroup) -> Result<(SigningPrivateKey, Certificate)> {
     let cert = crypto::read_pem_cert_file(&group.cert)
         .with_context(|| format!("Failed to load certificate: {:?}", group.cert))?;
 
-    Ok((signing_key, cert))
+    Ok((signing_key, cert, group.signing_method))
 }
 
 fn start_entry<'a>(
@@ -240,6 +240,7 @@ fn add_otacert_entry(
 fn finalize_ota(
     key: &SigningPrivateKey,
     cert: &Certificate,
+    method: SigningMethod,
     mut zip_writer: ZipArchiveWriter<SigningWriter<File>>,
     zip_mode: ZipMode,
     metadata_entries: &mut Vec<ZipEntry>,
@@ -267,7 +268,7 @@ fn finalize_ota(
         .finish()
         .context("Failed to finalize output zip")?;
     let mut raw_writer = signing_writer
-        .finish(key, cert, cancel_signal)
+        .finish(key, cert, method, cancel_signal)
         .context("Failed to sign output zip")?;
 
     raw_writer.rewind().context("Failed to seek output zip")?;
@@ -340,7 +341,7 @@ fn unpack_subcommand(zip_cli: &ZipCli, cli: &UnpackCli, cancel_signal: &AtomicBo
 }
 
 fn pack_subcommand(zip_cli: &ZipCli, cli: &PackCli, cancel_signal: &AtomicBool) -> Result<()> {
-    let (signing_key, cert) = load_key(&cli.key)?;
+    let (signing_key, cert, method) = load_key(&cli.key)?;
     let mut info = read_info(&cli.input_info)?;
     let mut zip_writer = open_writer(&cli.output, cli.zip_mode.zip_mode)?;
 
@@ -383,6 +384,7 @@ fn pack_subcommand(zip_cli: &ZipCli, cli: &PackCli, cancel_signal: &AtomicBool) 
                 &cli.input_payload_images,
                 &mut data_writer,
                 &signing_key,
+                method,
                 cancel_signal,
             )?;
 
@@ -424,6 +426,7 @@ fn pack_subcommand(zip_cli: &ZipCli, cli: &PackCli, cancel_signal: &AtomicBool) 
     finalize_ota(
         &signing_key,
         &cert,
+        method,
         zip_writer,
         cli.zip_mode.zip_mode,
         &mut metadata_entries,
@@ -446,7 +449,7 @@ fn pack_subcommand(zip_cli: &ZipCli, cli: &PackCli, cancel_signal: &AtomicBool) 
 }
 
 fn repack_subcommand(zip_cli: &ZipCli, cli: &RepackCli, cancel_signal: &AtomicBool) -> Result<()> {
-    let (signing_key, cert) = load_key(&cli.key)?;
+    let (signing_key, cert, method) = load_key(&cli.key)?;
     let (zip_reader, mut metadata, input_entries) = open_reader(&cli.input)?;
     let mut zip_writer = open_writer(&cli.output, cli.zip_mode.zip_mode)?;
 
@@ -487,6 +490,7 @@ fn repack_subcommand(zip_cli: &ZipCli, cli: &RepackCli, cancel_signal: &AtomicBo
     finalize_ota(
         &signing_key,
         &cert,
+        method,
         zip_writer,
         cli.zip_mode.zip_mode,
         &mut metadata_entries,
@@ -555,6 +559,21 @@ struct KeyGroup {
     /// <program> <algo> <public key> [file <pass file>|env <pass env>]
     #[arg(long, value_name = "PROGRAM", value_parser)]
     signing_helper: Option<PathBuf>,
+
+    /// Preferred signing method.
+    ///
+    /// Defaults to deterministic signatures. If the non-deterministic mode is
+    /// selected, but is not supported for a signing operation, then it will
+    /// fall back to deterministic signatures.
+    ///
+    /// For RSA, non-deterministic signatures are never supported because
+    /// Android uses the PKCS#1 v1.5 scheme.
+    ///
+    /// For ML-DSA, non-deterministic signatures use the hedged variant. This
+    /// can help reduce the impact of broken RNGs and side channel attacks at
+    /// the expense of the output no longer being byte-for-byte reproducible.
+    #[arg(long, default_value_t, conflicts_with = "signing_helper")]
+    signing_method: SigningMethod,
 }
 
 #[derive(Debug, Args)]

--- a/avbroot/src/crypto.rs
+++ b/avbroot/src/crypto.rs
@@ -5,6 +5,7 @@ use std::{
     borrow::Cow,
     env::{self, VarError},
     ffi::{OsStr, OsString},
+    fmt,
     fs::{self, File, OpenOptions},
     io::{self, Read, Write},
     path::{Path, PathBuf},
@@ -12,6 +13,7 @@ use std::{
     time::Duration,
 };
 
+use clap::ValueEnum;
 use cms::{
     cert::{CertificateChoices, IssuerAndSerialNumber},
     content_info::{CmsVersion, ContentInfo},
@@ -36,7 +38,10 @@ use rand::{
     Rng, SeedableRng,
     rngs::{StdRng, SysRng},
 };
-use rsa::{Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey, pkcs1, pkcs1v15, traits::PublicKeyParts};
+use rsa::{
+    Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey, pkcs1, pkcs1v15, signature::RandomizedSigner,
+    traits::PublicKeyParts,
+};
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha512};
@@ -258,6 +263,19 @@ pub enum SigningKeyType {
 pub enum SigningContent<'a> {
     Data(&'a [u8]),
     Digest(&'a [u8]),
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum SigningMethod {
+    #[default]
+    Deterministic,
+    NonDeterministic,
+}
+
+impl fmt::Display for SigningMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_possible_value().ok_or(fmt::Error)?.get_name())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -552,7 +570,12 @@ impl SigningPrivateKey {
     ///
     /// * [`SigningContent::Data`] is supported for both RSA and ML-DSA.
     /// * [`SigningContent::Digest`] is only supported for RSA.
-    pub fn sign(&self, algo: SignatureAlgorithm, content: SigningContent) -> Result<Vec<u8>> {
+    pub fn sign(
+        &self,
+        method: SigningMethod,
+        algo: SignatureAlgorithm,
+        content: SigningContent,
+    ) -> Result<Vec<u8>> {
         let key_type = self.key_type();
 
         match self {
@@ -576,6 +599,7 @@ impl SigningPrivateKey {
                     return Err(Error::InvalidDigestLength(digest.len(), algo));
                 }
 
+                // PKCS#1 v1.5 signatures are always deterministic.
                 key.sign(scheme, &digest)
                     .map_err(|e| Error::RsaSign(Box::new(e)))
             }
@@ -588,11 +612,18 @@ impl SigningPrivateKey {
                     return Err(Error::UnsupportedMlDsaDigest);
                 };
 
-                Ok(key
-                    .try_sign(data)
-                    .map_err(Error::MlDsaSign)?
-                    .encode()
-                    .into())
+                let signature = match method {
+                    SigningMethod::Deterministic => key.try_sign(data).map_err(Error::MlDsaSign)?,
+                    SigningMethod::NonDeterministic => {
+                        let mut rng = csprng()?;
+
+                        key.expanded_key()
+                            .try_sign_with_rng(&mut rng, data)
+                            .map_err(Error::MlDsaSign)?
+                    }
+                };
+
+                Ok(signature.encode().into())
             }
             Self::MlDsa87(key) => {
                 if algo != SignatureAlgorithm::MlDsa87 {
@@ -603,14 +634,21 @@ impl SigningPrivateKey {
                     return Err(Error::UnsupportedMlDsaDigest);
                 };
 
-                Ok(key
-                    .try_sign(data)
-                    .map_err(Error::MlDsaSign)?
-                    .encode()
-                    .into())
+                let signature = match method {
+                    SigningMethod::Deterministic => key.try_sign(data).map_err(Error::MlDsaSign)?,
+                    SigningMethod::NonDeterministic => {
+                        let mut rng = csprng()?;
+
+                        key.expanded_key()
+                            .try_sign_with_rng(&mut rng, data)
+                            .map_err(Error::MlDsaSign)?
+                    }
+                };
+
+                Ok(signature.encode().into())
             }
             // sign_external() will check that the algorithm is compatible with
-            // the key.
+            // the key. The signing method is ignored.
             Self::External { .. } => self.sign_external(algo, content),
         }
     }
@@ -1011,9 +1049,11 @@ pub fn iter_cms_certs(sd: &SignedData) -> impl Iterator<Item = &Certificate> {
 pub fn cms_sign_external(
     key: &SigningPrivateKey,
     cert: &Certificate,
+    method: SigningMethod,
     digest: &[u8],
 ) -> Result<ContentInfo> {
     let signature = key.sign(
+        method,
         SignatureAlgorithm::Sha256WithRsa,
         SigningContent::Digest(digest),
     )?;

--- a/avbroot/src/format/avb.rs
+++ b/avbroot/src/format/avb.rs
@@ -22,7 +22,7 @@ use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
     crypto::{
-        self, SignatureAlgorithm, SigningContent, SigningKeyType, SigningPrivateKey,
+        self, SignatureAlgorithm, SigningContent, SigningKeyType, SigningMethod, SigningPrivateKey,
         SigningPublicKey,
     },
     escape,
@@ -266,7 +266,12 @@ impl AlgorithmType {
         algo.hash(data)
     }
 
-    pub fn sign(self, key: &SigningPrivateKey, data: &[u8]) -> Result<Vec<u8>> {
+    pub fn sign(
+        self,
+        key: &SigningPrivateKey,
+        method: SigningMethod,
+        data: &[u8],
+    ) -> Result<Vec<u8>> {
         let Some(algo) = self.to_signature_algorithm() else {
             return if self == Self::None {
                 Ok(vec![])
@@ -275,7 +280,7 @@ impl AlgorithmType {
             };
         };
 
-        key.sign(algo, SigningContent::Data(data))
+        key.sign(method, algo, SigningContent::Data(data))
             .map_err(Error::HeaderSign)
     }
 
@@ -1731,7 +1736,7 @@ impl Header {
         self.public_key_metadata.clear();
     }
 
-    pub fn sign(&mut self, key: &SigningPrivateKey) -> Result<()> {
+    pub fn sign(&mut self, key: &SigningPrivateKey, method: SigningMethod) -> Result<()> {
         let key_raw = encode_public_key(&key.to_public_key())?;
 
         if key_raw.len() != self.algorithm_type.public_key_len() {
@@ -1750,7 +1755,7 @@ impl Header {
         let without_auth = without_auth_writer.into_inner();
 
         let hash = self.algorithm_type.hash(&without_auth);
-        let signature = self.algorithm_type.sign(key, &without_auth)?;
+        let signature = self.algorithm_type.sign(key, method, &without_auth)?;
 
         self.hash = hash;
         self.signature = signature;

--- a/avbroot/src/format/bootimage.rs
+++ b/avbroot/src/format/bootimage.rs
@@ -17,7 +17,7 @@ use zerocopy::{FromBytes, IntoBytes, little_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
-    crypto::SigningPrivateKey,
+    crypto::{SigningMethod, SigningPrivateKey},
     format::{
         avb::{self, Descriptor, Header},
         padding::{self, ZeroPadding},
@@ -883,7 +883,7 @@ impl BootImageV3Through4 {
     /// Sign the boot image with a legacy VTS signature. Returns true if the
     /// image was successfully signed. Returns false if there's no vbmeta
     /// structure to sign in [`V4Extra::signature`].
-    pub fn sign(&mut self, key: &SigningPrivateKey) -> Result<bool> {
+    pub fn sign(&mut self, key: &SigningPrivateKey, method: SigningMethod) -> Result<bool> {
         let mut context = Context::new(&ring::digest::SHA256);
         let image_size;
 
@@ -939,7 +939,7 @@ impl BootImageV3Through4 {
 
         descriptor.image_size = image_size;
         descriptor.root_digest = context.finish().as_ref().to_vec();
-        signature.sign(key).map_err(Error::VtsAvbSign)?;
+        signature.sign(key, method).map_err(Error::VtsAvbSign)?;
 
         Ok(true)
     }

--- a/avbroot/src/format/ota.rs
+++ b/avbroot/src/format/ota.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use x509_cert::Certificate;
 
 use crate::{
-    crypto::{self, SignatureAlgorithm, SigningContent, SigningPrivateKey},
+    crypto::{self, SignatureAlgorithm, SigningContent, SigningMethod, SigningPrivateKey},
     format::{
         payload::{self, PayloadHeader},
         zip::{self, ZipEntriesSafeExt, ZipFileHeaderRecordExt},
@@ -964,10 +964,11 @@ fn validate_eocd(eocd: &[u8]) -> Result<()> {
 fn compute_signature_comment(
     key: &SigningPrivateKey,
     cert: &Certificate,
+    method: SigningMethod,
     digest: ring::digest::Digest,
 ) -> Result<Vec<u8>> {
     let cms_signature =
-        crypto::cms_sign_external(key, cert, digest.as_ref()).map_err(Error::CmsSign)?;
+        crypto::cms_sign_external(key, cert, method, digest.as_ref()).map_err(Error::CmsSign)?;
     let cms_signature_der = cms_signature.to_der().map_err(Error::CmsSave)?;
 
     // Includes placeholder for the EOCD comment size field.
@@ -1022,7 +1023,12 @@ impl<W: Write> StreamingSigningWriter<W> {
         }
     }
 
-    pub fn finish(mut self, key: &SigningPrivateKey, cert: &Certificate) -> Result<W> {
+    pub fn finish(
+        mut self,
+        key: &SigningPrivateKey,
+        cert: &Certificate,
+        method: SigningMethod,
+    ) -> Result<W> {
         if self.used < self.queue.len() {
             return Err(Error::ZipTooSmall);
         }
@@ -1037,7 +1043,7 @@ impl<W: Write> StreamingSigningWriter<W> {
         let (mut raw_writer, context) = self.inner.finish();
         let digest = context.finish();
 
-        let size_and_comment = compute_signature_comment(key, cert, digest)?;
+        let size_and_comment = compute_signature_comment(key, cert, method, digest)?;
         raw_writer
             .write_all(&size_and_comment)
             .map_err(|e| Error::DataWrite("size_and_comment", e))?;
@@ -1098,6 +1104,7 @@ impl<W: Read + Write + Seek> SeekableSigningWriter<W> {
         mut self,
         key: &SigningPrivateKey,
         cert: &Certificate,
+        method: SigningMethod,
         cancel_signal: &AtomicBool,
     ) -> Result<W> {
         // We always write a streaming zip because that is what rawzip supports.
@@ -1134,7 +1141,7 @@ impl<W: Read + Write + Seek> SeekableSigningWriter<W> {
 
         let digest = hashing_writer.finish().1.finish();
 
-        let size_and_comment = compute_signature_comment(key, cert, digest)?;
+        let size_and_comment = compute_signature_comment(key, cert, method, digest)?;
         self.inner
             .write_all(&size_and_comment)
             .map_err(|e| Error::DataWrite("size_and_comment", e))?;
@@ -1179,6 +1186,7 @@ enum SigningWriterInner<W> {
             SeekableSigningWriter<W>,
             key: &SigningPrivateKey,
             cert: &Certificate,
+            method: SigningMethod,
             cancel_signal: &AtomicBool,
         ) -> Result<W>,
     },
@@ -1203,12 +1211,13 @@ impl<W: Write> SigningWriter<W> {
         self,
         key: &SigningPrivateKey,
         cert: &Certificate,
+        method: SigningMethod,
         cancel_signal: &AtomicBool,
     ) -> Result<W> {
         match self.0 {
-            SigningWriterInner::Streaming { inner } => inner.finish(key, cert),
+            SigningWriterInner::Streaming { inner } => inner.finish(key, cert, method),
             SigningWriterInner::Seekable { inner, finish } => {
-                finish(inner, key, cert, cancel_signal)
+                finish(inner, key, cert, method, cancel_signal)
             }
         }
     }

--- a/avbroot/src/format/payload.rs
+++ b/avbroot/src/format/payload.rs
@@ -30,7 +30,7 @@ use zerocopy::{FromBytes, IntoBytes, big_endian};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
-    crypto::{self, SignatureAlgorithm, SigningContent, SigningPrivateKey},
+    crypto::{self, SignatureAlgorithm, SigningContent, SigningMethod, SigningPrivateKey},
     protobuf::chromeos_update_engine::{
         DeltaArchiveManifest, Extent, InstallOperation, PartitionInfo, PartitionUpdate, Signatures,
         install_operation::Type, signatures::Signature,
@@ -221,9 +221,14 @@ impl<R: Read> FromReader<R> for PayloadHeader {
 }
 
 /// Sign `digest` with `key` and return a [`Signatures`] protobuf struct.
-fn sign_digest(digest: &[u8], key: &SigningPrivateKey) -> Result<Signatures> {
+fn sign_digest(
+    digest: &[u8],
+    key: &SigningPrivateKey,
+    method: SigningMethod,
+) -> Result<Signatures> {
     let digest_signed = key
         .sign(
+            method,
             SignatureAlgorithm::Sha256WithRsa,
             SigningContent::Digest(digest),
         )
@@ -341,6 +346,7 @@ pub struct PayloadWriter<W: Write> {
     /// Includes signatures (hashes are for properties file).
     h_full: Context,
     key: SigningPrivateKey,
+    method: SigningMethod,
 }
 
 /// Write data to a writer and one or more hashers.
@@ -363,7 +369,12 @@ impl<W: Write> PayloadWriter<W> {
     /// fields are ignored and internally recomputed to guarantee that there are
     /// no gaps. All partitions' install operation data is written to the blob
     /// section in order.
-    pub fn new(mut inner: W, mut header: PayloadHeader, key: SigningPrivateKey) -> Result<Self> {
+    pub fn new(
+        mut inner: W,
+        mut header: PayloadHeader,
+        key: SigningPrivateKey,
+        method: SigningMethod,
+    ) -> Result<Self> {
         let mut blob_size = 0;
 
         // The blob must contain all data in sequential order with no gaps.
@@ -383,6 +394,7 @@ impl<W: Write> PayloadWriter<W> {
         let dummy_sig = sign_digest(
             ring::digest::digest(&ring::digest::SHA256, b"").as_ref(),
             &key,
+            method,
         )?;
         let dummy_sig_size = dummy_sig.encoded_len();
 
@@ -415,7 +427,7 @@ impl<W: Write> PayloadWriter<W> {
         // Sign metadata (header + manifest) hash. The signature is not included
         // in the payload hash.
         let metadata_hash = h_partial.clone().finish();
-        let metadata_sig = sign_digest(metadata_hash.as_ref(), &key)?;
+        let metadata_sig = sign_digest(metadata_hash.as_ref(), &key, method)?;
         let metadata_sig_raw = metadata_sig.encode_to_vec();
         write_hash!(inner, [h_full], &metadata_sig_raw)
             .map_err(|e| Error::DataWrite("metadata_signatures", e))?;
@@ -432,6 +444,7 @@ impl<W: Write> PayloadWriter<W> {
             h_partial,
             h_full,
             key,
+            method,
         })
     }
 
@@ -444,7 +457,7 @@ impl<W: Write> PayloadWriter<W> {
     pub fn finish(mut self) -> Result<(W, PayloadHeader, String)> {
         // Append payload signature.
         let payload_partial_hash = self.h_partial.clone().finish();
-        let payload_sig = sign_digest(payload_partial_hash.as_ref(), &self.key)?;
+        let payload_sig = sign_digest(payload_partial_hash.as_ref(), &self.key, self.method)?;
         let payload_sig_raw = payload_sig.encode_to_vec();
         write_hash!(self.inner, [self.h_full], &payload_sig_raw)
             .map_err(|e| Error::DataWrite("payload_signatures", e))?;

--- a/avbroot/src/patch/boot.rs
+++ b/avbroot/src/patch/boot.rs
@@ -26,7 +26,7 @@ use tracing::{Span, debug, debug_span, trace, warn};
 use x509_cert::Certificate;
 
 use crate::{
-    crypto::{self, SigningPrivateKey, SigningPublicKey},
+    crypto::{self, SigningMethod, SigningPrivateKey, SigningPublicKey},
     format::{
         avb::{self, AppendedDescriptorMut, Footer, Header},
         bootimage::{self, BootImage, BootImageExt, RamdiskMeta},
@@ -1302,6 +1302,7 @@ fn save_boot_image(
     writer: &mut dyn WriteSeek,
     info: &mut BootImageInfo,
     key: &SigningPrivateKey,
+    method: SigningMethod,
 ) -> Result<()> {
     let AppendedDescriptorMut::Hash(descriptor) = info
         .header
@@ -1329,7 +1330,7 @@ fn save_boot_image(
         info.header
             .set_algo_for_key(key)
             .map_err(Error::AvbUpdate)?;
-        info.header.sign(key).map_err(Error::AvbUpdate)?;
+        info.header.sign(key, method).map_err(Error::AvbUpdate)?;
     }
 
     avb::write_appended_image(
@@ -1391,6 +1392,7 @@ pub fn patch_boot_images<'a>(
     names: &[&'a str],
     opener: &(dyn BootImageOpener + Sync),
     key: &SigningPrivateKey,
+    method: SigningMethod,
     patchers: &[Box<dyn BootImagePatch + Sync>],
     cancel_signal: &AtomicBool,
 ) -> TargetsResult<HashSet<&'a str>> {
@@ -1458,7 +1460,8 @@ pub fn patch_boot_images<'a>(
             .open_replacement(name)
             .map_err(|e| TargetsError::Open(name.to_owned(), e))?;
 
-        save_boot_image(&mut writer, info, key).map_err(|e| TargetsError::Save(name.to_owned(), e))
+        save_boot_image(&mut writer, info, key, method)
+            .map_err(|e| TargetsError::Save(name.to_owned(), e))
     })?;
 
     Ok(groups.keys().copied().collect())

--- a/avbroot/src/patch/system.rs
+++ b/avbroot/src/patch/system.rs
@@ -15,7 +15,7 @@ use tracing::{Span, debug, debug_span, trace};
 use x509_cert::Certificate;
 
 use crate::{
-    crypto::SigningPrivateKey,
+    crypto::{SigningMethod, SigningPrivateKey},
     format::{
         avb::{self, AppendedDescriptorMut, Footer},
         ota,
@@ -114,6 +114,7 @@ pub fn patch_system_image(
     raw_file: &(dyn ReadWriteAt + Sync),
     certificate: &Certificate,
     key: &SigningPrivateKey,
+    method: SigningMethod,
     cancel_signal: &AtomicBool,
 ) -> Result<(Vec<Range<u64>>, Vec<Range<u64>>)> {
     // This must be a multiple of normal filesystem block sizes (eg. 4 KiB).
@@ -199,7 +200,7 @@ pub fn patch_system_image(
     if !header.public_key.is_empty() {
         debug!("Signing system image");
         header.set_algo_for_key(key).map_err(Error::AvbUpdate)?;
-        header.sign(key).map_err(Error::AvbUpdate)?;
+        header.sign(key, method).map_err(Error::AvbUpdate)?;
     }
 
     let file = UserPosFile::new(raw_file);

--- a/avbroot/tests/avb.rs
+++ b/avbroot/tests/avb.rs
@@ -11,7 +11,7 @@ use pkcs8::DecodePrivateKey;
 
 use avbroot::{
     self,
-    crypto::SigningPrivateKey,
+    crypto::{SigningMethod, SigningPrivateKey},
     format::avb::{
         self, AlgorithmType, AppendedDescriptorMut, AppendedDescriptorRef,
         ChainPartitionDescriptor, Descriptor, Footer, HashDescriptor, HashTreeDescriptor, Header,
@@ -158,7 +158,7 @@ fn round_trip_root_image() {
         };
 
         // Sign the header.
-        header.sign(&key).unwrap();
+        header.sign(&key, SigningMethod::Deterministic).unwrap();
         assert_eq!(header.verify().unwrap().unwrap(), key.to_public_key());
 
         // Write vbmeta structures.
@@ -276,7 +276,7 @@ fn round_trip_appended_hash_image() {
         }
 
         // Sign the header.
-        header.sign(&key).unwrap();
+        header.sign(&key, SigningMethod::Deterministic).unwrap();
         assert_eq!(header.verify().unwrap().unwrap(), key.to_public_key());
 
         // Write vbmeta structures.
@@ -401,7 +401,7 @@ fn round_trip_appended_hash_tree_image_fixed_size() {
         }
 
         // Sign the header.
-        header.sign(&key).unwrap();
+        header.sign(&key, SigningMethod::Deterministic).unwrap();
         assert_eq!(header.verify().unwrap().unwrap(), key.to_public_key());
 
         // Write vbmeta structures.
@@ -529,7 +529,7 @@ fn round_trip_appended_hash_tree_image_minimum_size() {
         }
 
         // Sign the header.
-        header.sign(&key).unwrap();
+        header.sign(&key, SigningMethod::Deterministic).unwrap();
         assert_eq!(header.verify().unwrap().unwrap(), key.to_public_key());
 
         // Write vbmeta structures.
@@ -623,7 +623,7 @@ fn corrupted_root_image() {
         };
 
         // Sign the header.
-        header.sign(&key).unwrap();
+        header.sign(&key, SigningMethod::Deterministic).unwrap();
         assert_eq!(header.verify().unwrap().unwrap(), key.to_public_key());
 
         header.signature[0] = !header.signature[0];

--- a/avbroot/tests/bootimage.rs
+++ b/avbroot/tests/bootimage.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 
 use avbroot::{
     self,
-    crypto::SigningPrivateKey,
+    crypto::{SigningMethod, SigningPrivateKey},
     format::{
         avb::{AlgorithmType, Descriptor, HashDescriptor, Header},
         bootimage::{
@@ -240,7 +240,7 @@ fn round_trip_v4_vts() {
     // ML-DSA keys are not supported because the maximum size of a VTS signature
     // is 4096 bytes.
     let key = get_test_key_rsa();
-    header.sign(&key).unwrap();
+    header.sign(&key, SigningMethod::Deterministic).unwrap();
     assert_eq!(header.verify().unwrap().unwrap(), key.to_public_key());
 
     let image = BootImage::V3Through4(BootImageV3Through4 {

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -22,7 +22,7 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use avbroot::{
     cli::ota::{ExtractCli, PatchCli, VerifyCli},
-    crypto::{self, PassphraseSource, SigningKeyType, SigningPrivateKey},
+    crypto::{self, PassphraseSource, SigningKeyType, SigningMethod, SigningPrivateKey},
     format::{
         avb::{
             self, AlgorithmType, ChainPartitionDescriptor, Descriptor, Footer, HashDescriptor,
@@ -182,7 +182,7 @@ fn append_avb(
 
     if avb.signed {
         header.set_algo_for_key(key_avb)?;
-        header.sign(key_avb)?;
+        header.sign(key_avb, SigningMethod::Deterministic)?;
     }
 
     let mut footer = Footer {
@@ -502,7 +502,7 @@ fn create_vbmeta_image(
 
     if avb.signed {
         header.set_algo_for_key(key)?;
-        header.sign(key)?;
+        header.sign(key, SigningMethod::Deterministic)?;
     }
 
     avb::write_root_image(file, &header, 4096)
@@ -681,8 +681,13 @@ fn create_payload(
         blob_offset: 0,
     };
 
-    let mut payload_writer = PayloadWriter::new(writer, header.clone(), key_ota.clone())
-        .context("Failed to write payload header")?;
+    let mut payload_writer = PayloadWriter::new(
+        writer,
+        header.clone(),
+        key_ota.clone(),
+        SigningMethod::Deterministic,
+    )
+    .context("Failed to write payload header")?;
 
     while payload_writer
         .begin_next_operation()
@@ -848,7 +853,12 @@ fn create_ota(
         .finish()
         .context("Failed to finalize output zip")?;
     let mut buffered_writer = signing_writer
-        .finish(key_ota, cert_ota, cancel_signal)
+        .finish(
+            key_ota,
+            cert_ota,
+            SigningMethod::Deterministic,
+            cancel_signal,
+        )
         .context("Failed to sign output zip")?;
     buffered_writer
         .flush()


### PR DESCRIPTION
This is intended for ML-DSA where the "hedged" variant is recommended to mitigate against potential broken RNGs and side channel attacks.

Deterministic signatures continue to be the default for byte-for-byte reproducibility of the output files, but users can pass in `--signing-method non-deterministic` if desired.

https://www.ietf.org/archive/id/draft-ietf-lamps-cms-ml-dsa-02.html#section-4-4

Issue: #585