### PR TITLE
Exclude estimate_op_count_max from payload.toml

### DIFF
--- a/avbroot/build.rs
+++ b/avbroot/build.rs
@@ -74,6 +74,7 @@ fn main() {
         .field_attribute(c!(CUE_DAM, ".signatures_size"), SERDE_SKIP)
         .field_attribute(c!(CUE_PU, ".operations"), SERDE_SKIP)
         .field_attribute(c!(CUE_PU, ".estimate_cow_size"), SERDE_SKIP)
+        .field_attribute(c!(CUE_PU, ".estimate_op_count_max"), SERDE_SKIP)
         .field_attribute(c!(CUE_PU, ".old_partition_info"), SERDE_SKIP)
         .field_attribute(c!(CUE_PU, ".new_partition_info"), SERDE_SKIP)
         // Don't serialize AVB 1.0 fields.


### PR DESCRIPTION
Like `estimate_cow_size`, this is a field that avbroot recalculates during payload packing and cannot be modified by the user. This was meant to be excluded already, but was missed when support for CoW version 3 was added.

Issue: #631